### PR TITLE
Make children optional, correctness changes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
 declare module 'react-intersection-observer' {
-  import * as React from 'react';
+  import React = require('react');
 
-  export type IntersectionObserverProps = {
+  export interface IntersectionObserverProps {
     /** Children should be either a function or a node */
-    children: JSX.Element | null | ((inView: boolean) => JSX.Element | null);
+    children?: React.ReactNode | ((inView: boolean) => React.ReactNode);
 
     /**
      * The `HTMLElement` that is used as the viewport for checking visibility of
@@ -47,10 +47,10 @@ declare module 'react-intersection-observer' {
     triggerOnce?: boolean;
 
     /** Call this function whenever the in view state changes */
-    onChange?(inView: boolean): void;
+    onChange?(inView: boolean|React.FormEvent<HTMLElement>): void;
 
     /** Use `render` method to only render content when inView */
-    render?(): JSX.Element | null;
+    render?(): React.ReactNode;
   };
 
   export default class IntersectionObserver extends React.Component<


### PR DESCRIPTION
The children can also be any ReactNode in React 16, as opposed to only JSX.Element. Even in React 15, the current definitions exclude `string` and `number`.

Don't import `React` with ES imports because it's not an ES module. Use a commonjs import to avoid future issues when TypeScript finally fixes their stuff.

`children` is optional, especially when `render` is provided.

The `onChange` is passed through to the top level element so if the `tag` happens to be one with an `onChange` event, the `onChange` callback may be called with `React.FormEvent`.