### PR TITLE
fixed typescript error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ declare module 'react-intersection-observer' {
 
     /** Use `render` method to only render content when inView */
     render?(): React.ReactNode;
-  };
+  }
 
   export default class IntersectionObserver extends React.Component<
     IntersectionObserverProps,


### PR DESCRIPTION
Building with typescript 2.6.1 with this module included gave the error, 

```
node_modules/react-intersection-observer/index.d.ts(54,4): error TS1036: Statements are not allowed in ambient contexts.

54   };
```

It's an easy fix of simply removing the `;`.
