### PR TITLE
Fix render prop example

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ import Observer from 'react-intersection-observer'
 
 const Component = () => (
   <Observer
-    render={(inView) => (
+    render={
       inView => <h2>{`Header inside viewport ${inView}.`}</h2>
-    )}
+    }
   />
 )
 


### PR DESCRIPTION
The render prop example shows the function being passed to `render` returning another function, where it should just return some JSX like in the "child as function" example above it.

(P.S. shouldn't that be "function as child"?)