### PR TITLE
Simplify the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,54 +35,20 @@ npm install react-intersection-observer --save
 
 ### Child as function
 
-The easiest way to use the `Observer`, is to pass a function as the child. It
-will be called whenever the state changes, with the new value of `inView`.
-By default it will render inside a `<div>`, but you can change the element by setting `tag` to the HTMLElement you need.
+To use the `Observer`, you pass it a function. It will be called whenever the state changes, with the new value of `inView`.
+In addition to the `inView` prop, children also receives a `ref` that should be set on the containing DOM element.
+This is the element that the IntersectionObserver will monitor.
 
 ```js
 import Observer from 'react-intersection-observer'
 
 const Component = () => (
   <Observer>
-    {inView => <h2>{`Header inside viewport ${inView}.`}</h2>}
-  </Observer>
-)
-
-export default Component
-```
-
-### Render prop
-
-Using the render prop you can get full control over the output.
-In addition to the `inView` prop, the render also receives a `ref` that should be set on the containing DOM element.
-
-```js
-import Observer from 'react-intersection-observer'
-
-const Component = () => (
-  <Observer
-    render={({ inView, ref }) => (
+    {({ inView, ref }) => (
       <div ref={ref}>
         <h2>{`Header inside viewport ${inView}.`}</h2>
       </div>
     )}
-  />
-)
-
-export default Component
-```
-
-### OnChange callback
-
-You can monitor the onChange method, and control the state in your own
-component. This works with plain children, child as function or render props.
-
-```js
-import Observer from 'react-intersection-observer'
-
-const Component = () => (
-  <Observer onChange={inView => console.log('Inview:', inView)}>
-    <h2>Plain children are always rendered. Use onChange to monitor state.</h2>
   </Observer>
 )
 
@@ -95,15 +61,13 @@ The **`<Observer />`** accepts the following props:
 
 | Name            | Type                    | Default | Required | Description                                                                                                                                                                                                                      |
 | --------------- | ----------------------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **children**    | Func/Node               |         | false    | Children should be either a function or a node                                                                                                                                                                                   |
-| **render**      | ({inView, ref}) => Node |         | false    | Render prop allowing you to control the view.                                                                                                                                                                                    |
+| **children**    | ({inView, ref}) => Node |         | true     | Children expects a function that recieves an object contain an `inView` boolean and `ref` that should be assigned to the element root.                                                                                           |
+| **onChange**    | (inView) => void        |         | false    | Call this function whenever the in view state changes                                                                                                                                                                            |
 | **root**        | HTMLElement             |         | false    | The HTMLElement that is used as the viewport for checking visibility of the target. Defaults to the browser viewport if not specified or if null.                                                                                |
 | **rootId**      | String                  |         | false    | Unique identifier for the root element - This is used to identify the IntersectionObserver instance, so it can be reused. If you defined a root element, without adding an id, it will create a new instance for all components. |
 | **rootMargin**  | String                  | '0px'   | false    | Margin around the root. Can have values similar to the CSS margin property, e.g. "10px 20px 30px 40px" (top, right, bottom, left).                                                                                               |
-| **tag**         | String                  | 'div'   | false    | Element tag to use for the wrapping element when rendering using 'children'. Defaults to 'div'                                                                                                                                   |
 | **threshold**   | Number                  | 0       | false    | Number between 0 and 1 indicating the the percentage that should be visible before triggering. Can also be an array of numbers, to create multiple trigger points.                                                               |
 | **triggerOnce** | Bool                    | false   | false    | Only trigger this method once                                                                                                                                                                                                    |
-| **onChange**    | Func                    |         | false    | Call this function whenever the in view state changes                                                                                                                                                                            |
 
 ## Usage in other projects
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,11 +6,8 @@ export interface RenderProps {
 }
 
 export interface IntersectionObserverProps {
-  /** Children should be either a function or a node */
-  children?: React.ReactNode | ((inView: boolean) => React.ReactNode)
-
-  /** Render prop boolean indicating inView state */
-  render?: (fields: RenderProps) => React.ReactNode
+  /** Children expects a function that recieves an object contain an `inView` boolean and `ref` that should be assigned to the element root. */
+  children?: (fields: RenderProps) => React.ReactNode
 
   /**
    * The `HTMLElement` that is used as the viewport for checking visibility of
@@ -33,12 +30,6 @@ export interface IntersectionObserverProps {
    * e.g. `"10px 20px 30px 40px"` (top, right, bottom, left).
    */
   rootMargin?: string
-
-  /**
-   * Element tag to use for the wrapping component
-   * @default `'div'`
-   */
-  tag?: string
 
   /** Number between 0 and 1 indicating the the percentage that should be
    * visible before triggering. Can also be an array of numbers, to create

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:lib": "run-p rollup:*",
     "build:storybook": "build-storybook --output-dir example",
     "build:flow": "node scripts/create-flow",
-    "dev": "concurrently -k -r 'jest --watch' 'npm run storybook'",
+    "dev": "concurrently -k -r 'jest --watch' 'yarn run storybook'",
     "lint": "eslint {src,stories,tests}/**/*.js ",
     "rollup:es": "rollup -c --environment FORMAT:es",
     "rollup:cjs": "rollup -c --environment FORMAT:cjs",

--- a/src/index.js
+++ b/src/index.js
@@ -4,19 +4,20 @@ import { observe, unobserve } from './intersection'
 import invariant from 'invariant'
 
 type Props = {
-  /** Element tag to use for the wrapping element when rendering using 'children'. Defaults to 'div' */
-  tag: string,
-  /** Only trigger the inView callback once */
-  triggerOnce: boolean,
-  /** Children should be either a function or a node */
-  children?: ((inView: boolean) => React.Node) | React.Node,
-  /** Render prop boolean indicating inView state */
+  /** Children expects a function that recieves an object contain an `inView` boolean and `ref` that should be assigned to the element root. */
+  children?: ({
+    inView: boolean,
+    ref: (node: ?HTMLElement) => void,
+  }) => React.Node,
+  /** @deprecated replace render with children */
   render?: ({
     inView: boolean,
     ref: (node: ?HTMLElement) => void,
   }) => React.Node,
   /** Number between 0 and 1 indicating the the percentage that should be visible before triggering. Can also be an array of numbers, to create multiple trigger points. */
   threshold?: number | Array<number>,
+  /** Only trigger the inView callback once */
+  triggerOnce: boolean,
   /** The HTMLElement that is used as the viewport for checking visibility of the target. Defaults to the browser viewport if not specified or if null.*/
   root?: HTMLElement,
   /** Margin around the root. Can have values similar to the CSS margin property, e.g. "10px 20px 30px 40px" (top, right, bottom, left). */
@@ -36,14 +37,13 @@ type State = {
  * Monitors scroll, and triggers the children function with updated props
  *
  <Observer>
- {inView => (
-   <h1>{`${inView}`}</h1>
+ {({inView, ref}) => (
+   <h1 ref={ref}>{`${inView}`}</h1>
  )}
  </Observer>
  */
 class Observer extends React.Component<Props, State> {
   static defaultProps = {
-    tag: 'div',
     threshold: 0,
     triggerOnce: false,
   }
@@ -53,10 +53,15 @@ class Observer extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    if (typeof this.props.render === 'function') {
+    if (process.env.NODE_ENV !== 'production') {
+      if (this.props.hasOwnProperty('render')) {
+        console.warn(
+          `react-intersection-observer: "render" is deprecated, and should be replaced with "children"`,
+        )
+      }
       invariant(
         this.node,
-        `react-intersection-observer: No DOM node found. Make sure you forward "ref" to the root DOM element you want to observe, when using render prop.`,
+        `react-intersection-observer: No DOM node found. Make sure you forward "ref" to the root DOM element you want to observe.`,
       )
     }
   }
@@ -121,7 +126,6 @@ class Observer extends React.Component<Props, State> {
     const {
       children,
       render,
-      tag,
       triggerOnce,
       threshold,
       root,
@@ -131,21 +135,13 @@ class Observer extends React.Component<Props, State> {
     } = this.props
 
     const { inView } = this.state
+    const renderMethod = children || render
 
-    if (typeof render === 'function') {
-      return render({ inView, ref: this.handleNode })
+    if (typeof renderMethod === 'function') {
+      return renderMethod({ inView, ref: this.handleNode })
     }
 
-    return React.createElement(
-      tag,
-      {
-        ...props,
-        ref: this.handleNode,
-      },
-      // If children is a function, render it with the current inView status.
-      // Otherwise always render children. Assume onChange is being used outside, to control the the state of children.
-      typeof children === 'function' ? children(inView) : children,
-    )
+    return null
   }
 }
 

--- a/stories/Observer.story.js
+++ b/stories/Observer.story.js
@@ -9,12 +9,13 @@ import RootComponent from './Root'
 type Props = {
   style?: Object,
   children?: React.Node,
-  innerRef?: Function,
+  ref?: Function,
 }
 
-const Header = (props: Props) => (
+// $FlowFixMe forwardRef is not known
+const Header = React.forwardRef((props, ref) => (
   <div
-    ref={props.innerRef}
+    ref={ref}
     style={{
       display: 'flex',
       minHeight: '25vh',
@@ -29,13 +30,15 @@ const Header = (props: Props) => (
   >
     <h2>{props.children}</h2>
   </div>
-)
+))
 
 storiesOf('Intersection Observer', module)
-  .add('Child as function', () => (
+  .add('Basic', () => (
     <ScrollWrapper>
       <Observer onChange={action('Child Observer inview')}>
-        {inView => <Header>Header inside viewport: {inView.toString()}</Header>}
+        {({ inView, ref }) => (
+          <Header ref={ref}>Header inside viewport: {inView.toString()}</Header>
+        )}
       </Observer>
     </ScrollWrapper>
   ))
@@ -44,27 +47,18 @@ storiesOf('Intersection Observer', module)
       <Observer
         onChange={action('Render Observer inview')}
         render={({ inView, ref }) => (
-          <Header innerRef={ref}>
+          <Header ref={ref}>
             Header is inside viewport: {inView.toString()}
           </Header>
         )}
       />
     </ScrollWrapper>
   ))
-  .add('Plain child', () => (
-    <ScrollWrapper>
-      <Observer onChange={action('Plain Observer inview')}>
-        <Header>
-          Plain children are always rendered. Use onChange to monitor state.
-        </Header>
-      </Observer>
-    </ScrollWrapper>
-  ))
   .add('Taller then viewport', () => (
     <ScrollWrapper>
       <Observer onChange={action('Child Observer inview')}>
-        {inView => (
-          <Header style={{ height: '150vh' }}>
+        {({inView, ref}) => (
+          <Header ref={ref} style={{ height: '150vh' }}>
             Header is inside the viewport: {inView.toString()}
           </Header>
         )}
@@ -74,8 +68,8 @@ storiesOf('Intersection Observer', module)
   .add('With threshold 100%', () => (
     <ScrollWrapper>
       <Observer threshold={1} onChange={action('Child Observer inview')}>
-        {inView => (
-          <Header>
+        {({ inView, ref }) => (
+          <Header ref={ref}>
             Header is fully inside the viewport: {inView.toString()}
           </Header>
         )}
@@ -85,8 +79,8 @@ storiesOf('Intersection Observer', module)
   .add('With threshold 50%', () => (
     <ScrollWrapper>
       <Observer threshold={0.5} onChange={action('Child Observer inview')}>
-        {inView => (
-          <Header>
+        {({ inView, ref }) => (
+          <Header ref={ref}>
             Header is 50% inside the viewport: {inView.toString()}
           </Header>
         )}
@@ -96,8 +90,8 @@ storiesOf('Intersection Observer', module)
   .add('Taller then viewport with threshold 100%', () => (
     <ScrollWrapper>
       <Observer threshold={1}>
-        {inView => (
-          <Header style={{ height: '150vh' }}>
+        {({ inView, ref }) => (
+          <Header ref={ref} style={{ height: '150vh' }}>
             Header is fully inside the viewport: {inView.toString()}
           </Header>
         )}
@@ -110,8 +104,8 @@ storiesOf('Intersection Observer', module)
         threshold={[0, 0.25, 0.5, 0.75, 1]}
         onChange={action('Hit threshold trigger')}
       >
-        {inView => (
-          <Header>
+        {({ inView, ref }) => (
+          <Header ref={ref}>
             Header is inside threshold: {inView.toString()} - onChange triggers
             multiple times.
           </Header>
@@ -130,8 +124,8 @@ storiesOf('Intersection Observer', module)
             rootId="window1"
             onChange={action('Child Observer inview')}
           >
-            {inView => (
-              <Header>
+            {({ inView, ref }) => (
+              <Header ref={ref}>
                 Header is inside the root viewport: {inView.toString()}
               </Header>
             )}
@@ -151,8 +145,8 @@ storiesOf('Intersection Observer', module)
             rootId="window2"
             onChange={action('Child Observer inview')}
           >
-            {inView => (
-              <Header>
+            {({ inView, ref }) => (
+              <Header ref={ref}>
                 Header is inside the root viewport: {inView.toString()}
               </Header>
             )}
@@ -168,8 +162,8 @@ storiesOf('Intersection Observer', module)
         triggerOnce
         onChange={action('Child Observer inview')}
       >
-        {inView => (
-          <Header>
+        {({ inView, ref }) => (
+          <Header ref={ref}>
             Header was fully inside the viewport: {inView.toString()}
           </Header>
         )}
@@ -179,15 +173,15 @@ storiesOf('Intersection Observer', module)
   .add('Multiple observers', () => (
     <ScrollWrapper>
       <Observer threshold={1} onChange={action('Child Observer inview')}>
-        {inView => (
-          <Header>
+        {({ inView, ref }) => (
+          <Header ref={ref}>
             Header 1 is fully inside the viewport: {inView.toString()}
           </Header>
         )}
       </Observer>
       <Observer threshold={1} onChange={action('Child Observer inview')}>
-        {inView => (
-          <Header>
+        {({ inView, ref }) => (
+          <Header ref={ref}>
             Header 2 is fully inside the viewport: {inView.toString()}
           </Header>
         )}

--- a/tests/Observer.test.js
+++ b/tests/Observer.test.js
@@ -11,54 +11,36 @@ jest.mock('invariant')
 afterEach(() => {})
 
 it('Should render <Observer />', () => {
-  const callback = jest.fn()
+  const callback = jest.fn(() => null)
   mount(<Observer>{callback}</Observer>)
-  expect(callback).toHaveBeenCalledWith(false)
+  expect(callback).toHaveBeenLastCalledWith(
+    expect.objectContaining({ inView: false }),
+  )
 })
 
 it('Should render <Observer /> inview', () => {
-  const callback = jest.fn()
+  const callback = jest.fn(() => null)
   const wrapper = mount(<Observer>{callback}</Observer>)
   wrapper.setState({ inView: true })
-  expect(callback).toHaveBeenLastCalledWith(true)
-})
-
-it('Should render <Observer /> with children outside view', () => {
-  const wrapper = mount(
-    <Observer className="observer">
-      <div>Content</div>
-    </Observer>,
+  expect(callback).toHaveBeenLastCalledWith(
+    expect.objectContaining({ inView: true }),
   )
-  expect(wrapper).toMatchSnapshot()
-})
-
-it('Should render <Observer /> with children inview', () => {
-  const wrapper = mount(
-    <Observer className="observer">
-      <div>Content</div>
-    </Observer>,
-  )
-  expect(wrapper).toMatchSnapshot()
 })
 
 it('Should not render <Observer /> render outside view', () => {
   const wrapper = mount(
-    <Observer
-      render={({ inView, ref }) => (
-        <div ref={ref}>Inview: {inView.toString()}</div>
-      )}
-    />,
+    <Observer>
+      {({ inView, ref }) => <div ref={ref}>Inview: {inView.toString()}</div>}
+    </Observer>,
   )
   expect(wrapper).toMatchSnapshot()
 })
 
 it('Should render <Observer /> render when in view', () => {
   const wrapper = mount(
-    <Observer
-      render={({ inView, ref }) => (
-        <div ref={ref}>Inview: {inView.toString()}</div>
-      )}
-    />,
+    <Observer>
+      {({ inView, ref }) => <div ref={ref}>Inview: {inView.toString()}</div>}
+    </Observer>,
   )
   wrapper.setState({ inView: true })
 
@@ -66,7 +48,11 @@ it('Should render <Observer /> render when in view', () => {
 })
 
 it('Should unobserve old node', () => {
-  const wrapper = mount(<Observer>Content</Observer>)
+  const wrapper = mount(
+    <Observer>
+      {({ inView, ref }) => <div ref={ref}>Inview: {inView.toString()}</div>}
+    </Observer>,
+  )
   const instance = wrapper.instance()
   jest.spyOn(instance, 'observeNode')
   const node = wrapper.getDOMNode()
@@ -151,7 +137,7 @@ it('Should unobserve when triggerOnce comes into view', () => {
   expect(intersection.unobserve).toHaveBeenCalledWith(node)
 })
 
-it('Should unobserve when unounted', () => {
+it('Should unobserve when unmounted', () => {
   const wrapper = mount(<Observer>Content</Observer>)
   const node = wrapper.getDOMNode()
   wrapper.instance().componentWillUnmount()
@@ -162,12 +148,12 @@ it('Should throw error when not passing ref', () => {
   invariant.mockReset()
 
   mount(
-    <Observer
-      render={({ inView, ref }) => <div>Inview: {inView.toString()}</div>}
-    />,
+    <Observer>
+      {({ inView, ref }) => <div>Inview: {inView.toString()}</div>}
+    </Observer>,
   )
   expect(invariant).toHaveBeenLastCalledWith(
     null,
-    'react-intersection-observer: No DOM node found. Make sure you forward "ref" to the root DOM element you want to observe, when using render prop.',
+    'react-intersection-observer: No DOM node found. Make sure you forward "ref" to the root DOM element you want to observe.',
   )
 })

--- a/tests/__snapshots__/Observer.test.js.snap
+++ b/tests/__snapshots__/Observer.test.js.snap
@@ -2,8 +2,6 @@
 
 exports[`Should not render <Observer /> render outside view 1`] = `
 <Observer
-  render={[Function]}
-  tag="div"
   threshold={0}
   triggerOnce={false}
 >
@@ -16,48 +14,12 @@ exports[`Should not render <Observer /> render outside view 1`] = `
 
 exports[`Should render <Observer /> render when in view 1`] = `
 <Observer
-  render={[Function]}
-  tag="div"
   threshold={0}
   triggerOnce={false}
 >
   <div>
     Inview: 
     true
-  </div>
-</Observer>
-`;
-
-exports[`Should render <Observer /> with children inview 1`] = `
-<Observer
-  className="observer"
-  tag="div"
-  threshold={0}
-  triggerOnce={false}
->
-  <div
-    className="observer"
-  >
-    <div>
-      Content
-    </div>
-  </div>
-</Observer>
-`;
-
-exports[`Should render <Observer /> with children outside view 1`] = `
-<Observer
-  className="observer"
-  tag="div"
-  threshold={0}
-  triggerOnce={false}
->
-  <div
-    className="observer"
-  >
-    <div>
-      Content
-    </div>
   </div>
 </Observer>
 `;


### PR DESCRIPTION
This removes `render`, and changes `children` to only accept a function.

It'll still accept `render` but, throws a warning.