### PR TITLE
Expose intersectionRatio value to callback and render fns

### DIFF
--- a/src/__tests__/Observer.test.js
+++ b/src/__tests__/Observer.test.js
@@ -138,10 +138,10 @@ it('Should recreate observer when rootMargin change', () => {
 it('Should trigger onChange callback', () => {
   const onChange = jest.fn()
   const wrapper = mount(<Observer onChange={onChange}>{plainChild}</Observer>)
-  wrapper.instance().handleChange(true)
-  expect(onChange).toHaveBeenLastCalledWith(true)
-  wrapper.instance().handleChange(false)
-  expect(onChange).toHaveBeenLastCalledWith(false)
+  wrapper.instance().handleChange(true, 1)
+  expect(onChange).toHaveBeenLastCalledWith(true, 1)
+  wrapper.instance().handleChange(false, 0)
+  expect(onChange).toHaveBeenLastCalledWith(false, 0)
 })
 
 it('Should unobserve when triggerOnce comes into view', () => {

--- a/src/__tests__/intersection.test.js
+++ b/src/__tests__/intersection.test.js
@@ -121,7 +121,7 @@ it('should trigger onChange with ratio 0', () => {
     },
   ])
 
-  expect(cb).toHaveBeenCalledWith(true)
+  expect(cb).toHaveBeenCalledWith(true, 0)
   expect(instance.visible).toBe(true)
 })
 
@@ -139,7 +139,7 @@ it('should trigger onChange with multiple thresholds ', () => {
     },
   ])
 
-  expect(cb).toHaveBeenCalledWith(true)
+  expect(cb).toHaveBeenCalledWith(true, 0)
   expect(instance.visible).toBe(true)
 })
 
@@ -158,7 +158,7 @@ it('should trigger onChange with isIntersection', () => {
     },
   ])
 
-  expect(cb).toHaveBeenCalledWith(true)
+  expect(cb).toHaveBeenCalledWith(true, 0)
   expect(instance.visible).toBe(true)
 })
 
@@ -176,7 +176,7 @@ it('should not trigger if threshold is undefined', () => {
     },
   ])
 
-  expect(cb).toHaveBeenCalledWith(false)
+  expect(cb).toHaveBeenCalledWith(false, 0)
   expect(instance.visible).toBe(false)
 })
 
@@ -195,7 +195,7 @@ it('should trigger onChange with isIntersection false', () => {
     },
   ])
 
-  expect(cb).toHaveBeenCalledWith(false)
+  expect(cb).toHaveBeenCalledWith(false, 0)
   expect(instance.visible).toBe(false)
 })
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,14 @@ type Props = {
   children?:
     | (({
         inView: boolean,
+        intersectionRatio?: number,
         ref: (node: ?HTMLElement) => void,
       }) => React.Node)
     | React.Node,
   /** @deprecated replace render with children */
   render?: ({
     inView: boolean,
+    intersectionRatio?: number,
     ref: (node: ?HTMLElement) => void,
   }) => React.Node,
   /** Element tag to use for the wrapping element when rendering a plain React.Node. Defaults to 'div'  */
@@ -30,11 +32,12 @@ type Props = {
    * If you defined a root element, without adding an id, it will create a new instance for all components. */
   rootId?: string,
   /** Call this function whenever the in view state changes */
-  onChange?: (inView: boolean) => void,
+  onChange?: (inView: boolean, intersectionRatio: number) => void,
 }
 
 type State = {
   inView: boolean,
+  intersectionRatio: number,
 }
 
 /**
@@ -54,6 +57,7 @@ class Observer extends React.Component<Props, State> {
 
   state = {
     inView: false,
+    intersectionRatio: 0,
   }
 
   componentDidMount() {
@@ -120,10 +124,10 @@ class Observer extends React.Component<Props, State> {
     this.observeNode()
   }
 
-  handleChange = (inView: boolean) => {
-    this.setState({ inView })
+  handleChange = (inView: boolean, intersectionRatio: number) => {
+    this.setState({ inView, intersectionRatio })
     if (this.props.onChange) {
-      this.props.onChange(inView)
+      this.props.onChange(inView, intersectionRatio)
     }
   }
 
@@ -140,11 +144,11 @@ class Observer extends React.Component<Props, State> {
       ...props
     } = this.props
 
-    const { inView } = this.state
+    const { inView, intersectionRatio } = this.state
     const renderMethod = children || render
 
     if (typeof renderMethod === 'function') {
-      return renderMethod({ inView, ref: this.handleNode })
+      return renderMethod({ inView, intersectionRatio, ref: this.handleNode })
     }
 
     return React.createElement(

--- a/src/intersection.js
+++ b/src/intersection.js
@@ -1,7 +1,7 @@
 // @flow
 import invariant from 'invariant'
 
-type Callback = (inView: boolean) => void
+type Callback = (inView: boolean, intersectionRatio: number) => void
 
 type Instance = {
   callback: Callback,
@@ -154,7 +154,7 @@ function onChange(changes) {
       }
 
       instance.visible = inView
-      instance.callback(inView)
+      instance.callback(inView, intersectionRatio)
     }
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3663,9 +3663,9 @@ enzyme-to-json@^3.3.4:
   dependencies:
     lodash "^4.17.4"
 
-enzyme@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.5.1.tgz#aad0cbd005fee4cfd800b6451b64112b5374da67"
+enzyme@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.6.0.tgz#d213f280a258f61e901bc663d4cc2d6fd9a9dec8"
   dependencies:
     array.prototype.flat "^1.2.1"
     cheerio "^1.0.0-rc.2"


### PR DESCRIPTION
What do you think about exposing the `intersectionRatio` returned in the latest IntersectionObserver callback to the render function and `onChange` callback? Pretty small change, gives support for a different set of use cases.

Let me know what you think, and if you're down I can update README etc as well before merge.