### PR TITLE
Fix/hook update when exiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     ],
     "parser": "@typescript-eslint/parser",
     "plugins": [
-      "@typescript-eslint"
+      "@typescript-eslint",
+      "react-hooks"
     ],
     "settings": {
       "react": {
@@ -85,7 +86,9 @@
       }
     },
     "rules": {
-      "no-unused-vars": 0
+      "no-unused-vars": 0,
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn"
     }
   },
   "jest": {
@@ -138,6 +141,7 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-jsx-a11y": "6.x",
     "eslint-plugin-react": "7.x",
+    "eslint-plugin-react-hooks": "^1.5.0",
     "husky": "^1.3.1",
     "intersection-observer": "^0.5.1",
     "jest": "^24.4.0",

--- a/src/useInView.tsx
+++ b/src/useInView.tsx
@@ -14,39 +14,37 @@ export function useInView(options: IntersectionOptions = {}): HookResponse {
     entry: undefined,
   })
 
-  React.useEffect(
-    () => {
-      if (!ref) return
-      observe(
-        ref,
-        (inView, intersection) => {
-          // Only trigger a state update if inView has changed.
-          // This prevents an unnecessary extra state update during mount, when the element stats outside the viewport
-          if (inView !== state.inView || inView) {
-            setState({ inView, entry: intersection })
-
-            if (inView && options.triggerOnce) {
-              // If it should only trigger once, unobserve the element after it's inView
-              unobserve(ref)
-            }
-          }
-        },
-        options,
-      )
-
-      return () => {
-        unobserve(ref)
-      }
-    },
-    [
-      // Only create a new Observer instance if the ref or any of the options have been changed.
+  React.useEffect(() => {
+    if (!ref) return
+    observe(
       ref,
-      options.threshold,
-      options.root,
-      options.rootMargin,
-      options.triggerOnce,
-    ],
-  )
+      (inView, intersection) => {
+        // Only trigger a state update if inView has changed.
+        // This prevents an unnecessary extra state update during mount, when the element stats outside the viewport
+        if (inView !== state.inView || inView) {
+          setState({ inView, entry: intersection })
+
+          if (inView && options.triggerOnce) {
+            // If it should only trigger once, unobserve the element after it's inView
+            unobserve(ref)
+          }
+        }
+      },
+      options,
+    )
+
+    return () => {
+      unobserve(ref)
+    }
+  }, [
+    // Only create a new Observer instance if the ref or any of the options have been changed.
+    ref,
+    options.threshold,
+    options.root,
+    options.rootMargin,
+    options.triggerOnce,
+    state.inView,
+  ])
 
   React.useDebugValue(state.inView)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,6 +4244,11 @@ eslint-plugin-jsx-a11y@6.x:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
 
+eslint-plugin-react-hooks@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.5.0.tgz#cdd958cfff55bd5fa4f84db90d1490fb5ca4ae2b"
+  integrity sha512-iwDuWR2ReRgvJsNm8fXPtTKdg78IVQF8I4+am3ntztPf/+nPnWZfArFu6aXpaC75/iCYRrkqI8nPCYkxJstmpA==
+
 eslint-plugin-react@7.x:
   version "7.12.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"


### PR DESCRIPTION
Thank you for your work on this module! I tried out the hooks API and noticed it didn't fire an update when the target node leaves the viewport (it only fires the callback when it enters).
So I ran the examples with storybook locally and after adding the react-hooks eslint plugin, it complained about missing dependencies in the useEffect call. After adding the missing inView dependency it works as I would expect again.

Let me know if I need to update my PR or something!