### PR TITLE
refactor: change the Map loop to forEach

### DIFF
--- a/src/intersection.ts
+++ b/src/intersection.ts
@@ -112,18 +112,17 @@ export function unobserve(element: Element | null) {
     let rootObserved = false
     /* istanbul ignore else  */
     if (observerId) {
-      for (let [key, item] of INSTANCE_MAP) {
+      INSTANCE_MAP.forEach((item, key) => {
         if (key !== element) {
           if (item.observerId === observerId) {
             itemsLeft = true
             rootObserved = true
-            break
           }
           if (item.observer.root === root) {
             rootObserved = true
           }
         }
-      }
+      })
     }
     if (!rootObserved && root) ROOT_IDS.delete(root)
     if (observer && !itemsLeft) {

--- a/src/useInView.tsx
+++ b/src/useInView.tsx
@@ -15,32 +15,35 @@ export function useInView(options: IntersectionOptions = {}): HookResponse {
     entry: undefined,
   })
 
-  React.useEffect(() => {
-    if (!ref) return
-    observe(
+  React.useEffect(
+    () => {
+      if (!ref) return
+      observe(
+        ref,
+        (inView, intersection) => {
+          setState({ inView, entry: intersection })
+
+          if (inView && options.triggerOnce) {
+            // If it should only trigger once, unobserve the element after it's inView
+            unobserve(ref)
+          }
+        },
+        options,
+      )
+
+      return () => {
+        unobserve(ref)
+      }
+    },
+    [
+      // Only create a new Observer instance if the ref or any of the options have been changed.
       ref,
-      (inView, intersection) => {
-        setState({ inView, entry: intersection })
-
-        if (inView && options.triggerOnce) {
-          // If it should only trigger once, unobserve the element after it's inView
-          unobserve(ref)
-        }
-      },
-      options,
-    )
-
-    return () => {
-      unobserve(ref)
-    }
-  }, [
-    // Only create a new Observer instance if the ref or any of the options have been changed.
-    ref,
-    options.threshold,
-    options.root,
-    options.rootMargin,
-    options.triggerOnce,
-  ])
+      options.threshold,
+      options.root,
+      options.rootMargin,
+      options.triggerOnce,
+    ],
+  )
 
   React.useDebugValue(state.inView)
 


### PR DESCRIPTION
Using for...of created a lot of babel bloat, while requiring Symbol.iterator to be defined.