### PR TITLE
fix: typescript definition for PlainChildren

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prebuild": "rm -rf dist lib",
     "build": "run-s build:*",
     "build:lib": "rollup -c",
-    "build:ts": "tsc && tsc -p tsconfig.test.json",
+    "build:ts": "tsc -p tsconfig.build.json && tsc -p tsconfig.test.json",
     "dev": "concurrently -k -r 'jest --watch' 'yarn run storybook'",
     "lint": "eslint . --ext js,ts,tsx",
     "preversion": "yarn build",

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -1,5 +1,7 @@
 import * as React from 'react'
 
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+
 type RenderProps = {
   inView: boolean
   entry: IntersectionObserverEntry | undefined
@@ -33,17 +35,17 @@ export type PlainChildrenProps = IntersectionOptions & {
    * Render the wrapping element as this element.
    * @default `'div'`
    */
-  as?: React.ReactType<any>
+  as?: React.ElementType<any>
 
   /**
    * Element tag to use for the wrapping component
    * @deprecated Replace with the 'as' prop
    */
-  tag?: React.ReactType<any>
+  tag?: React.ElementType<any>
 
   /** Call this function whenever the in view state changes */
   onChange?: (inView: boolean, entry: IntersectionObserverEntry) => void
-} & React.HTMLProps<HTMLDivElement>
+} & Omit<React.HTMLProps<HTMLElement>, 'onChange'>
 
 export type HookResponse = [
   ((node?: Element | null) => void),

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,12 +1,11 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6",
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": ".",
+    "outDir": "dist",
     "noEmit": false
   },
+  "include": ["src/**/*"],
   "files": ["src/test-utils.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,12 +14,9 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "downlevelIteration": true,
-    "declaration": true,
-    "emitDeclarationOnly": true,
     "skipLibCheck": true,
-    "outDir": "dist",
-    "listEmittedFiles": true
+    "listEmittedFiles": true,
+    "noEmit": true
   },
-  "include": ["src/**/*"],
   "exclude": ["dist"]
 }


### PR DESCRIPTION
Work on improving the types for `PlainChildren` - See #202 
Create a new tsconfig for the build task. This ensures `tsc` is run on all files in the project,
while we still only emit the files in 'src'