### PR TITLE
Prevent endless loop when using ref as a callback

### DIFF
--- a/src/useInView.tsx
+++ b/src/useInView.tsx
@@ -3,19 +3,12 @@ import * as React from 'react'
 import { observe, unobserve } from './intersection'
 import { InViewHookResponse, IntersectionOptions } from './index'
 
-type State = {
-  inView: boolean
-  entry?: IntersectionObserverEntry
-}
-
 export function useInView(
   options: IntersectionOptions = {},
 ): InViewHookResponse {
   const ref = React.useRef<Element>()
-  const [state, setState] = React.useState<State>({
-    inView: false,
-    entry: undefined,
-  })
+  const entryRef = React.useRef<IntersectionObserverEntry>()
+  const [inView, setInView] = React.useState<boolean>(false)
 
   const setRef = React.useCallback(
     node => {
@@ -26,7 +19,8 @@ export function useInView(
         observe(
           node,
           (inView, intersection) => {
-            setState({ inView, entry: intersection })
+            setInView(inView)
+            entryRef.current = intersection
 
             if (inView && options.triggerOnce) {
               // If it should only trigger once, unobserve the element after it's inView
@@ -43,7 +37,7 @@ export function useInView(
     [options.threshold, options.root, options.rootMargin, options.triggerOnce],
   )
 
-  React.useDebugValue(state.inView)
+  React.useDebugValue(inView)
 
-  return [setRef, state.inView, state.entry]
+  return [setRef, inView, entryRef.current]
 }


### PR DESCRIPTION
Picking up from the advice in this issue https://github.com/thebuilder/react-intersection-observer/issues/186 I'm noticing an endless loop. Perhaps I'm misusing it but I think we should be able to treat anything called a `ref` as such.

[Sandbox is here](https://codesandbox.io/s/admiring-neumann-7t9is) - uncomment the code and you should see endless `console.log` statements.

This PR uses a ref for the intersection object instead, TBH I have no idea why setState on the `entry` object is causing this and wasn't able to come up with a reliable test to reproduce in Jest. Please advise if there's something I've not considered. 