### PR TITLE
Fix recipe for triggering animations

### DIFF
--- a/docs/Recipes.md
+++ b/docs/Recipes.md
@@ -93,7 +93,7 @@ import { useInView } from 'react-intersection-observer'
 import { useSpring, animated } from 'react-spring'
 
 const LazyAnimation = () => {
-  const [ref, inView] = useInView(ref, {
+  const [ref, inView] = useInView({
     rootMargin: '-100px 0',
   })
   const props = useSpring({ opacity: inView ? 1 : 0 })


### PR DESCRIPTION
Fixes #270 

The first argument to the `useInView` function should be a configuration object, not a ref.
This fixes the recipe for me