### PR TITLE
expose instance to the callback

### DIFF
--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -64,8 +64,8 @@ export function mockIsIntersecting(element: Element, isIntersecting: boolean) {
         time: Date.now() - instance.time,
       },
     ]
-    if (act) act(() => cb(entry))
-    else cb(entry)
+    if (act) act(() => cb(entry, instance))
+    else cb(entry, instance)
   } else {
     throw new Error(
       'No IntersectionObserver instance found for element. Is it still mounted in the DOM?',


### PR DESCRIPTION
The second argument to Intersection Observer callback is the instance of the current observer https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver. 

I am using this library to mock out an intersection observer implementation and is currently failing because I use the instance returned within the callback