### PR TITLE
Fix Lazy Load Image example

### DIFF
--- a/docs/Recipes.md
+++ b/docs/Recipes.md
@@ -49,7 +49,7 @@ const LazyImage = ({ width, height, src, ...rest }) => {
 
   return (
     <div
-      ref={supportsLazyLoading === false ? ref : undefined}
+      ref={!supportsLazyLoading ? ref : undefined}
       style={{
         position: 'relative',
         paddingBottom: `${(height / width) * 100}%`,


### PR DESCRIPTION
The latest version of the useNativeLatyLoading() Hook returns either
'false' or 'undefined', so the check needs to be changed to
'!supportsLazyLoading' in order to work properly.