### PR TITLE
Reset inView and entry when observed component is unmounted

### DIFF
--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -27,6 +27,17 @@ const LazyHookComponent = ({ options }) => {
   )
 }
 
+const UnmountableRefComponent = ({ mount }) => {
+  const [ref, inView] = useInView()
+
+  return (
+    <>
+      {mount && <div ref={ref} />}
+      {inView.toString()}
+    </>
+  )
+}
+
 test('should create a hook', () => {
   const { getByTestId } = render(<HookComponent />)
   const wrapper = getByTestId('wrapper')
@@ -73,4 +84,15 @@ test('should unmount the hook', () => {
   const instance = intersectionMockInstance(wrapper)
   unmount()
   expect(instance.unobserve).toHaveBeenCalledWith(wrapper)
+})
+
+test('inView should be false when component is unmounted', () => {
+  const { rerender, getByText } = render(
+    <UnmountableRefComponent mount={true} />,
+  )
+  mockAllIsIntersecting(true)
+
+  getByText('true')
+  rerender(<UnmountableRefComponent mount={false} />)
+  getByText('false')
 })

--- a/src/useInView.tsx
+++ b/src/useInView.tsx
@@ -43,6 +43,12 @@ export function useInView(
     [options.threshold, options.root, options.rootMargin, options.triggerOnce],
   )
 
+  React.useLayoutEffect(() => {
+    if (!ref.current && state.inView) {
+      setState({ inView: false, entry: undefined })
+    }
+  })
+
   React.useDebugValue(state.inView)
 
   return [setRef, state.inView, state.entry]


### PR DESCRIPTION
Fix #303

I'm not 100% sure of the need to use `React.useLayoutEffect` instead of `React.useEffect`, but it may be safer since we nee to execute the callback after the node has been removed from the ref by React (maybe after DOM mutations ?).