### PR TITLE
fix: don't clear the inView state if we get a node

### DIFF
--- a/src/useInView.tsx
+++ b/src/useInView.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import { observe, unobserve } from './intersection'
 import { InViewHookResponse, IntersectionOptions } from './index'
+import { useEffect } from 'react'
 
 type State = {
   inView: boolean
@@ -23,12 +24,6 @@ export function useInView(
     (node) => {
       if (ref.current) {
         unobserve(ref.current)
-
-        if (!node && !options.triggerOnce) {
-          // If we didn't get a new node, then reset the state (unless the hook is set to only `triggerOnce`)
-          // This ensures we correctly reflect the current state.
-          setState(initialState)
-        }
       }
 
       if (node) {
@@ -51,6 +46,14 @@ export function useInView(
     },
     [options.threshold, options.root, options.rootMargin, options.triggerOnce],
   )
+
+  useEffect(() => {
+    if (!ref.current && state !== initialState && !options.triggerOnce) {
+      // If we don't have a ref, then reset the state (unless the hook is set to only `triggerOnce`)
+      // This ensures we correctly reflect the current state.
+      setState(initialState)
+    }
+  })
 
   return [setRef, state.inView, state.entry]
 }

--- a/src/useInView.tsx
+++ b/src/useInView.tsx
@@ -41,7 +41,7 @@ export function useInView(
         )
       }
 
-      // Store a reference to the node
+      // Store a reference to the node, so we can unobserve it later
       ref.current = node
     },
     [options.threshold, options.root, options.rootMargin, options.triggerOnce],
@@ -50,7 +50,7 @@ export function useInView(
   useEffect(() => {
     if (!ref.current && state !== initialState && !options.triggerOnce) {
       // If we don't have a ref, then reset the state (unless the hook is set to only `triggerOnce`)
-      // This ensures we correctly reflect the current state.
+      // This ensures we correctly reflect the current state - If you aren't observing anything, then nothing is inView
       setState(initialState)
     }
   })

--- a/src/useInView.tsx
+++ b/src/useInView.tsx
@@ -24,12 +24,13 @@ export function useInView(
       if (ref.current) {
         unobserve(ref.current)
 
-        if (!options.triggerOnce) {
-          // Reset the state, unless the hook is set to only `triggerOnce`
-          // In that case, resetting the state would trigger another update.
+        if (!node && !options.triggerOnce) {
+          // If we didn't get a new node, then reset the state (unless the hook is set to only `triggerOnce`)
+          // This ensures we correctly reflect the current state.
           setState(initialState)
         }
       }
+
       if (node) {
         observe(
           node,


### PR DESCRIPTION
This is a potential fix for the infinite loop seen in #308 
Will need to try it out, to see if solves the issue