### PR TITLE
fix: shouldn't trigger onchange when skipping

### DIFF
--- a/src/InView.tsx
+++ b/src/InView.tsx
@@ -50,7 +50,8 @@ export class InView extends React.Component<
     if (
       prevProps.rootMargin !== this.props.rootMargin ||
       prevProps.root !== this.props.root ||
-      prevProps.threshold !== this.props.threshold
+      prevProps.threshold !== this.props.threshold ||
+      prevProps.skip !== this.props.skip
     ) {
       unobserve(this.node)
       this.observeNode()
@@ -86,7 +87,7 @@ export class InView extends React.Component<
   handleNode = (node?: Element | null) => {
     if (this.node) {
       unobserve(this.node)
-      if (!node && !this.props.triggerOnce) {
+      if (!node && !this.props.triggerOnce && !this.props.skip) {
         this.setState({ inView: false, entry: undefined })
       }
     }

--- a/src/__tests__/Observer.test.js
+++ b/src/__tests__/Observer.test.js
@@ -83,6 +83,25 @@ it('Should respect skip', () => {
   expect(observe).not.toHaveBeenCalled()
 })
 
+it('Should not trigger onChange whenn skipping', () => {
+  observe.mockImplementation((el, callback, options) => {
+    callback(true, {})
+  })
+  const onChange = jest.fn()
+  const { rerender } = render(
+    <Observer onChange={onChange}>{plainChild}</Observer>,
+  )
+  expect(onChange).toHaveBeenCalledTimes(1)
+
+  rerender(
+    <Observer skip onChange={onChange}>
+      {plainChild}
+    </Observer>,
+  )
+  expect(onChange).toHaveBeenCalledTimes(1)
+  expect(unobserve).toHaveBeenCalled()
+})
+
 it('Should unobserve old node', () => {
   const { rerender, container } = render(
     <Observer>


### PR DESCRIPTION
`onChange` could potentially be triggered when using the `<InView>` component, since it never removed the observer when setting `skip` later.