### PR TITLE
fix: add back default export for InView

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-
+import { InView } from './InView';
 export { InView } from './InView';
 export { useInView } from './useInView';
+export default InView;
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 


### PR DESCRIPTION
This is going to cause a Rollup warning when bundling, and will therefor be removed in version 9.0.0. Closes #381 

```
Entry module "src/index.tsx" is using named and default exports together. 
Consumers of your bundle will have to use `ReactIntersectionObserver["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning
```