### PR TITLE
Fix: recipes animation example to trigger once

### DIFF
--- a/docs/Recipes.md
+++ b/docs/Recipes.md
@@ -94,6 +94,7 @@ import { motion } from 'framer-motion';
 
 const LazyAnimation = () => {
   const [ref, inView] = useInView({
+    triggerOnce: true,
     rootMargin: '-100px 0px',
   });
 


### PR DESCRIPTION
Description of using intersection observer for animations suggest setting `triggerOnce`, while not doing it then in code example.