### PR TITLE
feat: use beforeEach instead of beforeAll

### DIFF
--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -8,7 +8,7 @@ type Item = {
 
 const observers = new Map<IntersectionObserver, Item>();
 
-beforeAll(() => {
+beforeEach(() => {
   /**
    * Create a custom IntersectionObserver mock, allowing us to intercept the observe and unobserve calls.
    * We keep track of the elements being observed, so when `mockAllIsIntersecting` is triggered it will


### PR DESCRIPTION
Currently, the test-utils utility sets up the IntersectionObserver mock in a `beforeAll`. Some test frameworks, such as jest, have an option to reset all mocks before each test. In jest this is `resetMocks: true`. When using this config option, jest resets the IntersectionObserver mock, causing tests to break.

This PR changes the implementation to set up the mock in a `beforeEach` so that it will be set up AFTER the resetting.

The `resetMocks: true` option is now set BY DEFAULT in create-react-app v4, so I expect this will be a common issue once folks upgrade.

See: https://jestjs.io/docs/en/configuration#resetmocks-boolean
See: https://github.com/facebook/create-react-app/blob/v4.0.0/CHANGELOG.md#jest