### PR TITLE
fix: ensure thresholds is defined

### DIFF
--- a/src/observers.ts
+++ b/src/observers.ts
@@ -57,7 +57,7 @@ function createObserver(options: IntersectionObserverInit) {
         // -Firefox ignores `threshold` when considering `isIntersecting`, so it will never be false again if `threshold` is > 0
         const inView =
           entry.isIntersecting &&
-          observer.thresholds.some(
+          (observer.thresholds ?? [0]).some(
             (threshold) => entry.intersectionRatio >= threshold,
           );
 


### PR DESCRIPTION
Sometimes the `thresholds` value on the `IntersectionObserver` instance could be `undefined`. Add a fallback to a default value in the cases where the browser doesn't set it.

This fixes #414 