### PR TITLE
fix: use WeakMap to avoid memory leak

### DIFF
--- a/src/observers.ts
+++ b/src/observers.ts
@@ -9,7 +9,7 @@ const ObserverMap = new Map<
   }
 >();
 
-const RootIds: Map<Element, string> = new Map();
+const RootIds: WeakMap<Element, string> = new WeakMap();
 
 let rootId = 0;
 


### PR DESCRIPTION
IntersectionObserver roots were tracked in a `Map`. This ensures it's possible to reuse the Intersection Observer instance if they share the same options. Changed to use a `WeakMap`, so unused `root` elements can be garbage collected.

Closes #462 