### PR TITLE
fix: undo the clear observers in test-utils

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { InView } from './InView';
 export { InView } from './InView';
 export { useInView } from './useInView';
-export { observe, _observerMap } from './observe';
+export { observe } from './observe';
 
 export default InView;
 

--- a/src/observe.ts
+++ b/src/observe.ts
@@ -1,6 +1,6 @@
 import { ObserverInstanceCallback } from './index';
 
-export const _observerMap = new Map<
+const observerMap = new Map<
   string,
   {
     id: string;
@@ -44,7 +44,7 @@ export function optionsToId(options: IntersectionObserverInit) {
 function createObserver(options: IntersectionObserverInit) {
   // Create a unique ID for this observer instance, based on the root, root margin and threshold.
   let id = optionsToId(options);
-  let instance = _observerMap.get(id);
+  let instance = observerMap.get(id);
 
   if (!instance) {
     // Create a map of elements this observer is going to observe. Each element has a list of callbacks that should be triggered, once it comes into view.
@@ -85,7 +85,7 @@ function createObserver(options: IntersectionObserverInit) {
       elements,
     };
 
-    _observerMap.set(id, instance);
+    observerMap.set(id, instance);
   }
 
   return instance;
@@ -128,7 +128,7 @@ export function observe(
     if (elements.size === 0) {
       // No more elements are being observer by this instance, so destroy it
       observer.disconnect();
-      _observerMap.delete(id);
+      observerMap.delete(id);
     }
   };
 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,5 +1,4 @@
 import { act } from 'react-dom/test-utils';
-import { _observerMap } from './index';
 
 type Item = {
   callback: IntersectionObserverCallback;
@@ -49,7 +48,6 @@ afterEach(() => {
   // @ts-ignore
   global.IntersectionObserver.mockClear();
   observers.clear();
-  _observerMap.clear();
 });
 
 function triggerIntersection(


### PR DESCRIPTION
#519 and #522  had the side effect of including all the source files in the package, because the `test-utils.ts` was importing the files. The package should only include the bundle (cjs,esm,umd) files, and the `test-utils.js` file.
