### PR TITLE
fix: Correct typo in test error

### DIFF
--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -163,6 +163,6 @@ export function intersectionMockInstance(
   }
 
   throw new Error(
-    'Failed to find IntersectionObserver for element. Is it being observer?',
+    'Failed to find IntersectionObserver for element. Is it being observed?',
   );
 }


### PR DESCRIPTION
Hello! I've been debugging an error in my tests and keep seeing what I believe is a typo in this error message. Small thing but figured I'd put up a PR to change it!