### PR TITLE
fix: correct microbundle output paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "react-intersection-observer",
   "version": "8.26.1",
   "description": "Monitor if a component is inside the viewport, using IntersectionObserver API",
-  "source": "src/index.tsx",
-  "main": "dist/react-intersection-observer.js",
-  "module": "dist/react-intersection-observer.m.js",
-  "esmodule": "dist/react-intersection-observer.esm.js",
-  "unpkg": "dist/react-intersection-observer.umd.js",
-  "typings": "dist/index.d.ts",
+  "source": "./src/index.tsx",
+  "main": "./dist/react-intersection-observer.js",
+  "module": "./dist/react-intersection-observer.esm.js",
+  "exports": "./dist/react-intersection-observer.modern.js",
+  "unpkg": "./dist/react-intersection-observer.umd.js",
+  "typings": "./dist/index.d.ts",
   "author": "Daniel Schmidt",
   "sideEffects": false,
   "repository": {
@@ -90,19 +90,19 @@
   },
   "size-limit": [
     {
-      "path": "dist/react-intersection-observer.m.js",
+      "path": "dist/react-intersection-observer.esm.js",
       "name": "InView",
       "import": "{ InView }",
       "limit": "1.8 kB"
     },
     {
-      "path": "dist/react-intersection-observer.m.js",
+      "path": "dist/react-intersection-observer.esm.js",
       "name": "useInView",
       "import": "{ useInView }",
       "limit": "1.3 kB"
     },
     {
-      "path": "dist/react-intersection-observer.m.js",
+      "path": "dist/react-intersection-observer.esm.js",
       "name": "observe",
       "import": "{ observe }",
       "limit": "1 kB"

--- a/scripts/build-copy.js
+++ b/scripts/build-copy.js
@@ -29,7 +29,7 @@ packageFieldsToRemove.forEach((field) => {
 });
 
 // Remove 'dist' from the files inside the 'dist' dir, after we move them
-const fields = ['main', 'module', 'unpkg', 'esmodule', 'typings'];
+const fields = ['main', 'module', 'unpkg', 'exports', 'typings'];
 fields.forEach((key) => (pck[key] = pck[key].replace('dist/', '')));
 
 fs.writeFileSync(


### PR DESCRIPTION
Microbundle had changed the name of the `modern` file, so it wasn't properly mapped in the `package.json`.