### PR TITLE
fix: use the default field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "exports": {
     "./test-utils": "./test-utils.js",
     ".": {
-      "import": "./react-intersection-observer.modern.mjs",
-      "require": "./react-intersection-observer.js"
+      "require": "./react-intersection-observer.js",
+      "default": "./react-intersection-observer.modern.mjs"
     }
   },
   "unpkg": "./dist/react-intersection-observer.umd.js",


### PR DESCRIPTION
MicroBundle expects the`default` field, and uses it to generate the correct name of the exported file. When using `import` the file wasn't generated.