### PR TITLE
fix: add esm as fallback module

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     }
   },
   "author": "Daniel Schmidt",
+  "license": "MIT",
   "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/thebuilder/react-intersection-observer.git"
   },
-  "license": "MIT",
   "keywords": [
     "react",
     "component",

--- a/package.json
+++ b/package.json
@@ -4,16 +4,22 @@
   "description": "Monitor if a component is inside the viewport, using IntersectionObserver API",
   "source": "./src/index.tsx",
   "main": "./dist/react-intersection-observer.js",
-  "module": "./dist/react-intersection-observer.mjs",
+  "module": "./dist/react-intersection-observer.esm.js",
+  "unpkg": "./dist/react-intersection-observer.umd.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    "./test-utils": "./test-utils.js",
+    "./test-utils": {
+      "default": "./dist/test-utils.js",
+      "types": "./dist/test-utils.d.ts"
+    },
     ".": {
-      "require": "./react-intersection-observer.js",
-      "default": "./react-intersection-observer.modern.mjs"
+      "module": "./dist/react-intersection-observer.esm.js",
+      "require": "./dist/react-intersection-observer.js",
+      "default": "./dist/react-intersection-observer.modern.mjs",
+      "types": "./dist/index.d.ts"
     }
   },
-  "unpkg": "./dist/react-intersection-observer.umd.js",
-  "typings": "./dist/index.d.ts",
+  "files": ["dist", "README.md", "LICENSE", "package.json"],
   "author": "Daniel Schmidt",
   "sideEffects": false,
   "repository": {
@@ -51,7 +57,6 @@
     "build": "run-s build:*",
     "build:bundle": "microbundle --name ReactIntersectionObserver --jsx React.createElement -f cjs,umd,es,modern --no-compress",
     "build:utils": "tsc -p tsconfig.test.json",
-    "build:copy": "node scripts/build-copy.js",
     "postbuild": "size-limit",
     "dev": "yarn run storybook",
     "lint": "eslint . --ext js,ts,tsx",
@@ -73,12 +78,7 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      [
-        "@semantic-release/npm",
-        {
-          "pkgRoot": "dist"
-        }
-      ],
+      "@semantic-release/npm",
       "@semantic-release/github"
     ]
   },
@@ -96,19 +96,19 @@
   },
   "size-limit": [
     {
-      "path": "dist/react-intersection-observer.mjs",
+      "path": "dist/react-intersection-observer.esm.js",
       "name": "InView",
       "import": "{ InView }",
       "limit": "1.8 kB"
     },
     {
-      "path": "dist/react-intersection-observer.mjs",
+      "path": "dist/react-intersection-observer.esm.js",
       "name": "useInView",
       "import": "{ useInView }",
       "limit": "1.3 kB"
     },
     {
-      "path": "dist/react-intersection-observer.mjs",
+      "path": "dist/react-intersection-observer.esm.js",
       "name": "observe",
       "import": "{ observe }",
       "limit": "1 kB"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist", "README.md", "LICENSE", "package.json"],
   "author": "Daniel Schmidt",
   "sideEffects": false,
   "repository": {
@@ -57,6 +56,7 @@
     "build": "run-s build:*",
     "build:bundle": "microbundle --name ReactIntersectionObserver --jsx React.createElement -f cjs,umd,es,modern --no-compress",
     "build:utils": "tsc -p tsconfig.test.json",
+    "build:copy": "node scripts/build-copy.js",
     "postbuild": "size-limit",
     "dev": "yarn run storybook",
     "lint": "eslint . --ext js,ts,tsx",
@@ -78,7 +78,12 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      "@semantic-release/npm",
+      [
+        "@semantic-release/npm",
+        {
+          "pkgRoot": "dist"
+        }
+      ],
       "@semantic-release/github"
     ]
   },

--- a/scripts/build-copy.js
+++ b/scripts/build-copy.js
@@ -36,6 +36,7 @@ const fields = [
   'exports',
   'esmodule',
   'exports',
+  'types',
   'typings',
 ];
 fields.forEach((key) => {


### PR DESCRIPTION
A possible fix for #560 - Seeing how another library ([SWR](https://github.com/vercel/swr/blob/main/package.json)) handles `module` and `exports`, add a fallback to `.esm.js` - See if this is used by old CRA.