### PR TITLE
fix: export module as `esm.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "description": "Monitor if a component is inside the viewport, using IntersectionObserver API",
   "source": "./src/index.tsx",
   "main": "./dist/react-intersection-observer.js",
-  "module": "./dist/react-intersection-observer.mjs",
+  "module": "./dist/react-intersection-observer.esm.js",
+  "unpkg": "./dist/react-intersection-observer.umd.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    "./test-utils": "./test-utils.js",
+    "./test-utils": "./dist/test-utils.js",
     ".": {
-      "require": "./react-intersection-observer.js",
-      "default": "./react-intersection-observer.modern.mjs"
+      "require": "./dist/react-intersection-observer.js",
+      "default": "./dist/react-intersection-observer.modern.mjs"
     }
   },
-  "unpkg": "./dist/react-intersection-observer.umd.js",
-  "typings": "./dist/index.d.ts",
   "author": "Daniel Schmidt",
   "sideEffects": false,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -96,19 +96,19 @@
   },
   "size-limit": [
     {
-      "path": "dist/react-intersection-observer.mjs",
+      "path": "dist/react-intersection-observer.esm.js",
       "name": "InView",
       "import": "{ InView }",
       "limit": "1.8 kB"
     },
     {
-      "path": "dist/react-intersection-observer.mjs",
+      "path": "dist/react-intersection-observer.esm.js",
       "name": "useInView",
       "import": "{ useInView }",
       "limit": "1.3 kB"
     },
     {
-      "path": "dist/react-intersection-observer.mjs",
+      "path": "dist/react-intersection-observer.esm.js",
       "name": "observe",
       "import": "{ observe }",
       "limit": "1 kB"

--- a/scripts/build-copy.js
+++ b/scripts/build-copy.js
@@ -36,6 +36,7 @@ const fields = [
   'exports',
   'esmodule',
   'exports',
+  'types',
   'typings',
 ];
 fields.forEach((key) => {


### PR DESCRIPTION
Trying to solve the mess that is NPM packages:

* `main` still points to a CommonJS (`.js`) file.
* `modules` points to a `.esm.js` file. This seems to be what most bundles (Webpack, Vite) use.
* `exports` includes both the CommonJS (`.js`) and `.mjs` export. This is what Node will look for.

This solves #560 for now.