### PR TITLE
fix: Add support for TS 4.7+ node16/next module

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,12 @@
   "unpkg": "./dist/react-intersection-observer.umd.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "./test-utils": "./dist/test-utils.js",
+    "./test-utils": {
+      "types": "./dist/test-utils.d.ts",
+      "default": "./dist/test-utils.js"
+    },
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/react-intersection-observer.js",
       "default": "./dist/react-intersection-observer.modern.mjs"
     }


### PR DESCRIPTION
in TS 4.7+, TypeScript introduced a node16/next module mode.

in this mode, if libraries are using "exports" field on package.json, each "exports" field needs "types" field, or fail to load typings.

for more information, see release note: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#esm-nodejs