### PR TITLE
feat: rewrite internals to use setState for `ref`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -91,7 +91,7 @@ module.exports = {
     'no-this-before-super': 'warn',
     'no-throw-literal': 'warn',
     'no-unexpected-multiline': 'warn',
-    'no-unreachable': 'wa' + 'rn',
+    'no-unreachable': 'warn',
     'no-unused-expressions': [
       'error',
       {

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -30,7 +30,7 @@ module.exports = {
   async viteFinal(config) {
     // The build fails to correctly minify the `ansi-to-html` module with esbuild, so we fallback to Terser.
     // It's a package used by "Storybook" for the Webpreview, so it's interesting why it fails.
-    config.build.minify = 'terser';
+    if (config.build) config.build.minify = 'terser';
 
     if (config.optimizeDeps) {
       config.optimizeDeps.include = [

--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ Provide these as the options argument in the `useInView` hook or as props on the
 
 The **`<InView />`** component also accepts the following props:
 
-| Name         | Type                                                 | Default     | Description                                                                                                                                                                                                                                                                                                                   |
-| ------------ | ---------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **as**       | `string`                                             | `'div'`     | Render the wrapping element as this element. Defaults to `div`.                                                                                                                                                                                                                                                               |
+| Name         | Type                                                 | Default     | Description                                                                                                                                                                                                                                                                                                                    |
+| ------------ | ---------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **as**       | `string`                                             | `'div'`     | Render the wrapping element as this element. Defaults to `div`.                                                                                                                                                                                                                                                                |
 | **children** | `({ref, inView, entry}) => ReactNode` or `ReactNode` | `undefined` | Children expects a function that receives an object containing the `inView` boolean and a `ref` that should be assigned to the element root. Alternatively pass a plain child, to have the `<InView />` deal with the wrapping element. You will also get the `IntersectionObserverEntry` as `entry`, giving you more details. |
 
 ### Intersection Observer v2 🧪
@@ -217,9 +217,9 @@ import { useInView } from 'react-intersection-observer';
 
 function Component(props) {
   const ref = useRef();
-  const [inViewRef, inView] = useInView();
+  const { ref: inViewRef, inView } = useInView();
 
-  // Use `useCallback` so we don't recreate the function on each render - Could result in infinite loop
+  // Use `useCallback` so we don't recreate the function on each render
   const setRefs = useCallback(
     (node) => {
       // Ref's from useRef needs to have the node assigned to `current`

--- a/src/stories/Hooks.story.tsx
+++ b/src/stories/Hooks.story.tsx
@@ -1,4 +1,3 @@
-import { action } from '@storybook/addon-actions';
 import { Meta, Story } from '@storybook/react';
 import { IntersectionOptions, InView, useInView } from '../index';
 import { motion } from 'framer-motion';
@@ -80,6 +79,7 @@ const story: Meta = {
       table: {
         disable: true,
       },
+      action: 'InView',
     },
   },
   args: {
@@ -96,10 +96,12 @@ const Template: Story<Props> = ({
   inlineRef,
   ...rest
 }) => {
+  // const onChange: IntersectionOptions['onChange'] = (inView, entry) => {
+  //   action('InView')(inView, entry);
+  // }
   const { options, error } = useValidateOptions(rest);
-  const { ref, inView, entry } = useInView(!error ? options : {});
+  const { ref, inView } = useInView(!error ? { ...options } : {});
   const [isLoading, setIsLoading] = useState(lazy);
-  action('InView')(inView, entry);
 
   useEffect(() => {
     if (isLoading) setIsLoading(false);

--- a/src/stories/Hooks.story.tsx
+++ b/src/stories/Hooks.story.tsx
@@ -139,7 +139,7 @@ LazyHookRendering.args = {
 };
 
 export const InlineRef = Template.bind({});
-LazyHookRendering.args = {
+InlineRef.args = {
   inlineRef: true,
 };
 

--- a/src/stories/Hooks.story.tsx
+++ b/src/stories/Hooks.story.tsx
@@ -28,6 +28,7 @@ type Props = IntersectionOptions & {
   style?: CSSProperties;
   className?: string;
   lazy?: boolean;
+  inlineRef?: boolean;
 };
 
 const story: Meta = {
@@ -88,7 +89,13 @@ const story: Meta = {
 
 export default story;
 
-const Template: Story<Props> = ({ style, className, lazy, ...rest }) => {
+const Template: Story<Props> = ({
+  style,
+  className,
+  lazy,
+  inlineRef,
+  ...rest
+}) => {
   const { options, error } = useValidateOptions(rest);
   const { ref, inView, entry } = useInView(!error ? options : {});
   const [isLoading, setIsLoading] = useState(lazy);
@@ -109,7 +116,11 @@ const Template: Story<Props> = ({ style, className, lazy, ...rest }) => {
   return (
     <ScrollWrapper indicators={options.initialInView ? 'bottom' : 'all'}>
       <Status inView={inView} />
-      <InViewBlock ref={ref} inView={inView} style={style}>
+      <InViewBlock
+        ref={inlineRef ? (node) => ref(node) : ref}
+        inView={inView}
+        style={style}
+      >
         <InViewIcon inView={inView} />
         <EntryDetails options={options} />
       </InViewBlock>
@@ -125,6 +136,11 @@ Basic.args = {};
 export const LazyHookRendering = Template.bind({});
 LazyHookRendering.args = {
   lazy: true,
+};
+
+export const InlineRef = Template.bind({});
+LazyHookRendering.args = {
+  inlineRef: true,
 };
 
 export const StartInView = Template.bind({});

--- a/src/useInView.tsx
+++ b/src/useInView.tsx
@@ -45,7 +45,7 @@ export function useInView({
   fallbackInView,
   onChange,
 }: IntersectionOptions = {}): InViewHookResponse {
-  const ref = React.useRef<Element | null>(null);
+  const [ref, setRef] = React.useState<Element | null>(null);
   const unobserve = React.useRef<Function>();
   const callback = React.useRef<IntersectionOptions['onChange']>();
   const [state, setState] = React.useState<State>({
@@ -54,28 +54,21 @@ export function useInView({
   });
 
   // Store the onChange callback in a `ref`, so we can access the latest instance
-  // inside the `useCallback`, but without triggering a rerender.
+  // inside the `useEffect`, but without triggering a rerender.
   callback.current = onChange;
 
-  const setRef = React.useCallback(
-    (node: Element) => {
-      ref.current = node;
+  React.useEffect(
+    () => {
       // Ensure we have node ref, and that we shouldn't skip observing
-      if (skip || !node) return;
+      if (skip || !ref) return;
 
-      // Store a reference the current unobserve function, so we can destroy it later
-      const previousObserver = unobserve.current;
-
-      // Create a new IntersectionObserver, and store the `unobserve` function.
       unobserve.current = observe(
-        node,
+        ref,
         (inView, entry) => {
           setState({
             inView,
             entry,
           });
-
-          // Trigger any onChange callback function
           if (callback.current) callback.current(inView, entry);
 
           if (entry.isIntersecting && triggerOnce && unobserve.current) {
@@ -96,11 +89,12 @@ export function useInView({
         fallbackInView,
       );
 
-      if (previousObserver) {
-        // Was already observing a node - Make sure we destroy the previous observer.
-        // Do it after we create the new one, so the IntersectionObserver instance can be reused.
-        previousObserver();
-      }
+      return () => {
+        if (unobserve.current) {
+          unobserve.current();
+          unobserve.current = undefined;
+        }
+      };
     },
     // We break the rule here, because we aren't including the actual `threshold` variable
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -108,6 +102,7 @@ export function useInView({
       // If the threshold is an array, convert it to a string, so it won't change between renders.
       // eslint-disable-next-line react-hooks/exhaustive-deps
       Array.isArray(threshold) ? threshold.toString() : threshold,
+      ref,
       root,
       rootMargin,
       triggerOnce,
@@ -118,27 +113,18 @@ export function useInView({
     ],
   );
 
-  // We break the rule here, since we want to ensure we check the `ref` instances on every render.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const entryTarget = state.entry?.target;
+
   React.useEffect(() => {
-    if (!ref.current && state.entry?.target && !triggerOnce && !skip) {
+    if (!ref && entryTarget && !triggerOnce && !skip) {
       // If we don't have a node ref, then reset the state (unless the hook is set to only `triggerOnce` or `skip`)
-      // This ensures we correctly reflect the current state - If you aren't observing anything, then nothing is inView.
+      // This ensures we correctly reflect the current state - If you aren't observing anything, then nothing is inView
       setState({
         inView: !!initialInView,
         entry: undefined,
       });
     }
-
-    return () => {
-      if (!ref.current && unobserve.current) {
-        // We no longer have a valid ref. Destroy the observer
-        unobserve.current();
-        unobserve.current = undefined;
-        ref.current = null;
-      }
-    };
-  });
+  }, [ref, entryTarget, triggerOnce, skip, initialInView]);
 
   const result = [setRef, state.inView, state.entry] as InViewHookResponse;
 

--- a/src/useInView.tsx
+++ b/src/useInView.tsx
@@ -53,7 +53,8 @@ export function useInView({
     entry: undefined,
   });
 
-  // Store the onChange callback in a `ref`, so we can access the latest instance inside the `useCallback`.
+  // Store the onChange callback in a `ref`, so we can access the latest instance
+  // inside the `useEffect`, but without triggering a rerender.
   callback.current = onChange;
 
   React.useEffect(


### PR DESCRIPTION
Rewrite the internals of `useInView` to allow it to handle inline ref functions, without causing infinite loops.

* Convert the `useCallback` ref function to a `useState` that triggers a `useEffect`.

Closes #572 