### PR TITLE
fix: cannot access 'unobserve' before initialization

### DIFF
--- a/src/useInView.tsx
+++ b/src/useInView.tsx
@@ -61,7 +61,8 @@ export function useInView({
       // Ensure we have node ref, and that we shouldn't skip observing
       if (skip || !ref) return;
 
-      let unobserve: (() => void) | undefined = observe(
+      let unobserve: (() => void) | undefined;
+      unobserve = observe(
         ref,
         (inView, entry) => {
           setState({


### PR DESCRIPTION
Hello!
I got an error `ReferenceError: cannot access 'unobserve' before initialization` when IntersectionObserver is undefined, fallbackInView and triggerOnce of useInView is true.
When that condition is met, 'unobserve' is before initialization at line 73 in useInView.tsx.
So I added an initialization line and created this PR. Please check it.
