### PR TITLE
fix: remove extra useEffect used for resetting initial state

### DIFF
--- a/src/useInView.tsx
+++ b/src/useInView.tsx
@@ -115,7 +115,6 @@ export function useInView({
   const entryTarget = state.entry?.target;
   const previousEntryTarget = React.useRef<Element>();
   if (
-    typeof window !== 'undefined' &&
     !ref &&
     entryTarget &&
     !triggerOnce &&

--- a/src/useInView.tsx
+++ b/src/useInView.tsx
@@ -113,17 +113,23 @@ export function useInView({
   );
 
   const entryTarget = state.entry?.target;
-
-  React.useEffect(() => {
-    if (!ref && entryTarget && !triggerOnce && !skip) {
-      // If we don't have a node ref, then reset the state (unless the hook is set to only `triggerOnce` or `skip`)
-      // This ensures we correctly reflect the current state - If you aren't observing anything, then nothing is inView
-      setState({
-        inView: !!initialInView,
-        entry: undefined,
-      });
-    }
-  }, [ref, entryTarget, triggerOnce, skip, initialInView]);
+  const previousEntryTarget = React.useRef<Element>();
+  if (
+    typeof window !== 'undefined' &&
+    !ref &&
+    entryTarget &&
+    !triggerOnce &&
+    !skip &&
+    previousEntryTarget.current !== entryTarget
+  ) {
+    // If we don't have a node ref, then reset the state (unless the hook is set to only `triggerOnce` or `skip`)
+    // This ensures we correctly reflect the current state - If you aren't observing anything, then nothing is inView
+    previousEntryTarget.current = entryTarget;
+    setState({
+      inView: !!initialInView,
+      entry: undefined,
+    });
+  }
 
   const result = [setRef, state.inView, state.entry] as InViewHookResponse;
 


### PR DESCRIPTION
This is an attempt to reduce the amount of re-renders generated by the `useInView` hook. We can leverage the built-in batching during the render cycle to eliminate the need for this reset `useEffect` that should have a really nice impact on performance. https://beta.reactjs.org/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes goes over an explanation of this, I honestly wasn't aware of the pattern until I read it but it seemed pertinent for here.

I'm not too familiar with vitest and couldn't determine a great way to test the number of re-renders in the current testing setup, but thought I'd open this to get your read on it before diving any deeper.

I see this referenced in https://github.com/thebuilder/react-intersection-observer/issues/572 so not sure if this has some of the issues you were initially running into or not. I upgraded to the latest version and noticed we'd doubled the re-renders so thought I'd see if there was a workaround.