### PR TITLE
fix: rename master to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
       - beta
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Version Badge][npm-version-svg]][package-url]
 [![GZipped size][npm-minzip-svg]][bundlephobia-url]
-[![Test][test-image]][test-url] [![License][license-image]][license-url]
+[![Test][test-image]][test-url] 
+[![License][license-image]][license-url]
 [![Downloads][downloads-image]][downloads-url]
 
 React implementation of the


### PR DESCRIPTION
Update the old `master` branch to modern `main`