### PR TITLE
fix: publish main with semantic releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "release": {
     "branches": [
-      "master",
+      "main",
       {
         "name": "beta",
         "prerelease": true


### PR DESCRIPTION
Ensure the package is published when PR's a merged to `main`