### PR TITLE
fix(typing): exclude 'as' property from HTMLElement

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,7 +62,7 @@ export type PlainChildrenProps = IntersectionOptions & {
 
   /** Call this function whenever the in view state changes */
   onChange?: (inView: boolean, entry: IntersectionObserverEntry) => void;
-} & Omit<React.HTMLProps<HTMLElement>, 'onChange'>;
+} & Omit<React.HTMLProps<HTMLElement>, 'onChange' | 'as'>;
 
 /**
  * The Hook response supports both array and object destructing


### PR DESCRIPTION
the 'as' property was clashing with HTML Element preventing us to pass a react element there when using typescript despite it working fine