### PR TITLE
Fix: typo in the comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,8 @@ In order to write meaningful tests, the `IntersectionObserver` needs to be
 mocked. You can use the included `react-intersection-observer/test-utils` to
 help with this. It mocks the `IntersectionObserver`, and includes a few methods
 to assist with faking the `inView` state. When setting the `isIntersecting`
-value you can pass either a `boolean` value or a threshold between 0 and 1.It
-wil emulate the real IntersectionObserver, allowing you to validate that your
+value you can pass either a `boolean` value or a threshold between 0 and 1. It
+will emulate the real IntersectionObserver, allowing you to validate that your
 components are behaving as expected.
 
 | Method                                        | Description                                                                                                                                                                       |

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -85,7 +85,7 @@ export function setupIntersectionMocking(mockFn: typeof jest.fn) {
 }
 
 /**
- * Rest the IntersectionObserver mock to its initial state, and clear all the elements being observed.
+ * Reset the IntersectionObserver mock to its initial state, and clear all the elements being observed.
  */
 export function resetIntersectionMocking() {
   // @ts-ignore


### PR DESCRIPTION
Fix the typo
- Comment in test-utils.ts `Rest -> Reset`.
- README.md `wil -> will`

