### PR TITLE
fix: add componentDidMount to InView

### DIFF
--- a/src/InView.tsx
+++ b/src/InView.tsx
@@ -74,6 +74,11 @@ export class InView extends React.Component<
     };
   }
 
+  componentDidMount() {
+    this.unobserve();
+    this.observeNode();
+  }
+
   componentDidUpdate(prevProps: IntersectionObserverProps) {
     // If a IntersectionObserver option changed, reinit the observer
     if (
@@ -91,7 +96,6 @@ export class InView extends React.Component<
 
   componentWillUnmount() {
     this.unobserve();
-    this.node = null;
   }
 
   node: Element | null = null;


### PR DESCRIPTION
Next.js has updated or changed React, causing it to call `componentWillUnmount`, followed by `componentDidMount`. The `componentDidMount` was not included in the `<InView>` component, causing it to just unmount itself.

This is most likely caused by StrictMode, similar to how it tests `useEffect`.
https://react.dev/reference/react/Component#componentdidmount

Why it hasn't been a problem before, and only affects the Next.js app router is a great question.

Fixes #649 