### PR TITLE
fix: use act from `react` instead of deprecated one

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -24,6 +24,9 @@
       "complexity": {
         "noForEach": "off"
       },
+      "style": {
+        "noVar": "off"
+      },
       "a11y": {
         "noSvgWithoutTitle": "off"
       }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,6 +1,5 @@
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 declare global {
-  // biome-ignore lint/style/noVar: Needs to be `var`, not `let` or `const`, for typing to work
   var IS_REACT_ACT_ENVIRONMENT: boolean;
 }
 type Item = {


### PR DESCRIPTION
- `act` is moved to `react` - https://react.dev/warnings/react-dom-test-utils
- Remove rule that caused Biome lint warning