### PR TITLE
fix: support old act from react-dom

### DIFF
--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import * as DeprecatedReactTestUtils from 'react-dom/test-utils';
+import * as React from "react";
+import * as DeprecatedReactTestUtils from "react-dom/test-utils";
 
 declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean;
 }
 
-const act = typeof React.act === 'function' ? React.act : DeprecatedReactTestUtils.act;
+const act =
+  typeof React.act === "function" ? React.act : DeprecatedReactTestUtils.act;
 
 type Item = {
   callback: IntersectionObserverCallback;

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import * as DeprecatedReactTestUtils from 'react-dom/test-utils'
+import * as React from 'react';
+import * as DeprecatedReactTestUtils from 'react-dom/test-utils';
 
 declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean;
 }
 
-const act = typeof React.act === 'function' ? React.act : DeprecatedReactTestUtils.act
+const act = typeof React.act === 'function' ? React.act : DeprecatedReactTestUtils.act;
 
 type Item = {
   callback: IntersectionObserverCallback;

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,7 +1,12 @@
-import { act } from "react";
+import * as React from 'react'
+import * as DeprecatedReactTestUtils from 'react-dom/test-utils'
+
 declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean;
 }
+
+const act = typeof React.act === 'function' ? React.act : DeprecatedReactTestUtils.act
+
 type Item = {
   callback: IntersectionObserverCallback;
   elements: Set<Element>;


### PR DESCRIPTION
Fetching `act` from `react-dom/test-utils` is deprecated, but keep support for it for now.

Fixes #674 