### PR TITLE
docs(README.md): replace the reference to `polyfill.io` with Cloudflare equivalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ const Component = () => {
 
 You can import the
 [polyfill](https://www.npmjs.com/package/intersection-observer) directly or use
-a service like [polyfill.io](https://polyfill.io/v2/docs/) to add it when
+a service like [https://cdnjs.cloudflare.com/polyfill](https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js) to add it when
 needed.
 
 ```sh


### PR DESCRIPTION
> polyfill.io, a popular JavaScript library service, can no longer be trusted and should be removed from websites.

Source: [https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet](https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet)
