### PR TITLE
ci: use pkg-pr-new to publish preview packages

### DIFF
--- a/.github/workflows/pkg-pr.yml
+++ b/.github/workflows/pkg-pr.yml
@@ -1,0 +1,23 @@
+name: Publish Approved Pull Requests
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  approved:
+    if: github.event.review.state == 'APPROVED'
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: corepack enable
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Publish preview package
+        run: pnpx pkg-pr-new publish


### PR DESCRIPTION
- Add [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) to preview packages before merging PR's.