### PR TITLE
ci: fix semantic release config

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,12 +66,7 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      [
-        "@semantic-release/npm",
-        {
-          "pkgRoot": "dist"
-        }
-      ],
+      "@semantic-release/npm",
       "@semantic-release/github"
     ]
   },


### PR DESCRIPTION
Semantic release was trying to publish the `dist` directory, instead of the `root`.
Fix this configuration.