### PR TITLE
Fix Playwright install script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Install playwright
-        run: pnpx playwright install chromium
+        run: pnpm exec playwright install
       - name: Lint
         run: pnpm biome ci .
       - name: Test
@@ -57,7 +57,8 @@ jobs:
       - name: Install ${{ matrix.react }}
         run: pnpm add -D react@${{ matrix.react }} react-dom@${{ matrix.react }}
       - name: Validate types
+        run: pnpm tsc
+      - name: Run test
         run: |
-          pnpm tsc
-          pnpx playwright install chromium
+          pnpm exec playwright install
           pnpm test

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "type": "git",
     "url": "https://github.com/thebuilder/react-intersection-observer.git"
   },
-  "packageManager": "pnpm@9.5.0+sha256.dbdf5961c32909fb030595a9daa1dae720162e658609a8f92f2fa99835510ca5",
+  "packageManager": "pnpm@9.7.0+sha256.b35018fbfa8f583668b2649e407922a721355cd81f61beeb4ac1d4258e585559",
   "scripts": {
     "prebuild": "rm -rf dist lib",
     "build": "tsup && mkdir dist/esm && cp dist/index.mjs dist/esm/index.js",


### PR DESCRIPTION
The command to install Playwright in the CI pipeline was incorrectly using `pnpx` instead `pnpm exec`