### PR TITLE
feat: restore beforeEach in test utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,12 +251,13 @@ will emulate the real IntersectionObserver, allowing you to validate that your
 components are behaving as expected.
 
 | Method                                        | Description                                                                                                                                                                       |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `mockAllIsIntersecting(isIntersecting)`       | Set `isIntersecting` on all current Intersection Observer instances. The value of `isIntersecting` should be either a `boolean` or a threshold between 0 and 1.                   |
 | `mockIsIntersecting(element, isIntersecting)` | Set `isIntersecting` for the Intersection Observer of a specific `element`. The value of `isIntersecting` should be either a `boolean` or a threshold between 0 and 1.            |
 | `intersectionMockInstance(element)`           | Call the `intersectionMockInstance` method with an element, to get the (mocked) `IntersectionObserver` instance. You can use this to spy on the `observe` and`unobserve` methods. |
 | `setupIntersectionMocking(mockFn)`            | Mock the `IntersectionObserver`, so we can interact with them in tests - Should be called in `beforeEach`. (**Done automatically in Jest environment**)                           |
-| `resetIntersectionMocking()`                  | Reset the mocks on `IntersectionObserver` - Should be called in `afterEach`. (**Done automatically in Jest environment**)                                                         |
+| `resetIntersectionMocking()`                  | Reset the mocks on `IntersectionObserver` - Should be called in `afterEach`. (**Done automatically in Jest/Vitest environment**)                                                  |
+| `destroyIntersectionMocking()`                | Destroy the mocked `IntersectionObserver` function, and return `window.IntersectionObserver` to the original browser implementation                                               |
 
 ### Testing Libraries
 

--- a/src/__tests__/hooks.test.tsx
+++ b/src/__tests__/hooks.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import React, { useCallback } from "react";
 import { type IntersectionOptions, defaultFallbackInView } from "../index";
 import {
+  destroyIntersectionMocking,
   intersectionMockInstance,
   mockAllIsIntersecting,
   mockIsIntersecting,
@@ -342,6 +343,7 @@ test("should set intersection ratio as the largest threshold smaller than trigge
 });
 
 test("should handle fallback if unsupported", () => {
+  destroyIntersectionMocking();
   // @ts-ignore
   window.IntersectionObserver = undefined;
   const { rerender } = render(
@@ -363,6 +365,7 @@ test("should handle fallback if unsupported", () => {
 });
 
 test("should handle defaultFallbackInView if unsupported", () => {
+  destroyIntersectionMocking();
   // @ts-ignore
   window.IntersectionObserver = undefined;
   defaultFallbackInView(true);
@@ -382,4 +385,13 @@ test("should handle defaultFallbackInView if unsupported", () => {
   }).toThrowErrorMatchingInlineSnapshot(
     `[TypeError: IntersectionObserver is not a constructor]`,
   );
+});
+
+test("should restore the browser IntersectingObserver", () => {
+  expect(vi.isMockFunction(window.IntersectionObserver)).toBe(true);
+  destroyIntersectionMocking();
+
+  // This should restore the original IntersectionObserver
+  expect(window.IntersectionObserver).toBeDefined();
+  expect(vi.isMockFunction(window.IntersectionObserver)).toBe(false);
 });


### PR DESCRIPTION
This PR changes to `test-utils`, to ensure mocking is configured in a reliable manner when using Jest

- Add back `beforeEach` to trigger the automatic mocking. This was removed in  #689 
- Keep the `beforeAll` hook
- Add a check to `setupIntersectionMocking` method, so it only runs if mocking hasn't been set up
- Introduce a `destroyIntersectionMocking` method to clear all mocking, and revert to the browser implementation

Closes #699 