### PR TITLE
Correctly detect global testing framework

### DIFF
--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -1,10 +1,14 @@
 import { vi } from "vitest";
-import { mockAllIsIntersecting } from "../test-utils";
+import { mockAllIsIntersecting, setupIntersectionMocking } from "../test-utils";
 
 vi.hoisted(() => {
   // Clear the `vi` from global, so we can detect if this is a test env
   // @ts-ignore
   window.vi = undefined;
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
 });
 
 test("should warn if not running in test env", () => {
@@ -25,4 +29,11 @@ beforeEach(() => {
 afterEach(() => {
   resetIntersectionMocking();
 });`);
+});
+
+test('should not warn if running in test env with global "vi"', () => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  setupIntersectionMocking(vi.fn);
+  mockAllIsIntersecting(true);
+  expect(console.error).not.toHaveBeenCalled();
 });

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -34,6 +34,16 @@ function isMocking() {
   if (util && typeof util.isMockFunction === "function") {
     return util.isMockFunction(window.IntersectionObserver);
   }
+
+  // No global test utility found. Check if the IntersectionObserver was manually mocked.
+  if (
+    typeof window !== "undefined" &&
+    window.IntersectionObserver &&
+    "mockClear" in window.IntersectionObserver
+  ) {
+    return true;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
Fixes issue in #689 

Improvements to test setup:

* [`src/__tests__/setup.test.ts`](diffhunk://#diff-f1ecdee188215e294f908cfdf10d3bd646e18f5801c76e0a54f18c8c5273a62cR33-R39): Added a new test to ensure no warnings are logged when running in the test environment with global `vi`.

Enhancements to mocking utilities:

* [`src/test-utils.ts`](diffhunk://#diff-26d4dc52e61d263a4256bed7c9ae3a9044b18a52f96f4f6840ca46336fb9216fR37-R46): Enhanced the `isMocking` function to check if `IntersectionObserver` was manually mocked.