### PR TITLE
chore: update package url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/thebuilder/react-intersection-observer.git"
+    "url": "git+https://github.com/thebuilder/react-intersection-observer.git"
   },
   "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b",
   "scripts": {


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change updates the repository URL to use the `git+https` protocol.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L38-R38): Updated the repository URL from `https` to `git+https`.