### PR TITLE
Fix minor grammatical issue in documentation intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,8 @@
 [![License][license-image]][license-url]
 [![Downloads][downloads-image]][downloads-url]
 
-React implementation of the
-[Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
-to tell you when an element enters or leaves the viewport. Contains both a
-[Hooks](#useinview-hook), [render props](#render-props) and
-[plain children](#plain-children) implementation.
+A React implementation of the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) 
+to tell you when an element enters or leaves the viewport. Contains [Hooks](#useinview-hook), [render props](#render-props), and [plain children](#plain-children) implementations.
 
 ## Features
 


### PR DESCRIPTION
## This PR fixes a minor grammatical issue in the documentation intro

- **Before**: React implementation of the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to tell you when an element enters or leaves the viewport. Contains both a [Hooks](https://github.com/thebuilder/react-intersection-observer#useinview-hook), [render props](https://github.com/thebuilder/react-intersection-observer#render-props) and [plain children](https://github.com/thebuilder/react-intersection-observer#plain-children) implementation.

- **After**: A React implementation of the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to tell you when an element enters or leaves the viewport. Contains [Hooks](https://github.com/akshay-vs/react-intersection-observer#useinview-hook), [render props](https://github.com/akshay-vs/react-intersection-observer#render-props), and [plain children](https://github.com/akshay-vs/react-intersection-observer#plain-children) implementations.

#### No functional changes, documentation only