### PR TITLE
feat: refactor useInView to utilize useOnInView and useCallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,7 @@ Provide these as the options argument in the `useInView` hook or as props on the
 | **initialInView**      | `boolean`                 | `false`     | Set the initial value of the `inView` boolean. This can be used if you expect the element to be in the viewport to start with, and you want to trigger something when it leaves.                                                                                                                |
 | **fallbackInView**     | `boolean`                 | `undefined` | If the `IntersectionObserver` API isn't available in the client, the default behavior is to throw an Error. You can set a specific fallback behavior, and the `inView` value will be set to this instead of failing. To set a global default, you can set it with the `defaultFallbackInView()` |
 
-`useOnInView` accepts the same options as `useInView` except `onChange`,
-`initialInView`, and `fallbackInView`.
+`useOnInView` accepts the same options as `useInView` except `onChange`.
 
 ### InView Props
 

--- a/src/__tests__/useOnInView.test.tsx
+++ b/src/__tests__/useOnInView.test.tsx
@@ -1,9 +1,11 @@
 import { render } from "@testing-library/react";
-import { useCallback, useEffect, useState } from "react";
+import * as React from "react";
 import type { IntersectionEffectOptions } from "..";
+import { supportsRefCleanup } from "../reactVersion";
 import { intersectionMockInstance, mockAllIsIntersecting } from "../test-utils";
 import { useOnInView } from "../useOnInView";
 
+const { useCallback, useEffect, useState } = React;
 const OnInViewChangedComponent = ({
   options,
   unmount,
@@ -309,6 +311,9 @@ const MultipleCallbacksComponent = ({
   const mergedRefs = useCallback(
     (node: Element | null) => {
       const cleanup = [ref1(node), ref2(node), ref3(node)];
+      if (!supportsRefCleanup) {
+        return;
+      }
       return () =>
         cleanup.forEach((fn) => {
           fn?.();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -90,7 +90,4 @@ export type InViewHookResponse = [
   entry?: IntersectionObserverEntry;
 };
 
-export type IntersectionEffectOptions = Omit<
-  IntersectionOptions,
-  "onChange" | "fallbackInView" | "initialInView"
->;
+export type IntersectionEffectOptions = IntersectionOptions;

--- a/src/reactVersion.ts
+++ b/src/reactVersion.ts
@@ -1,0 +1,5 @@
+import * as React from "react";
+
+const major = Number.parseInt(React.version?.split(".")[0] ?? "", 10);
+// NaN => unknown version; default to false to avoid returning ref cleanup on <19.
+export const supportsRefCleanup = Number.isFinite(major) && major >= 19;


### PR DESCRIPTION
This pull request refactors the `useInView` and `useOnInView` hooks to improve compatibility with React 19's ref cleanup behavior, simplifies option handling, and fixes inconsistencies between the hooks' option types. 

Importantly, it keeps support for React 17/18, while supporting the new `useCallback`.

Because it now uses the `useOnInView` hook, it means `entry` will be undefined until the first time it's added.

### React 19 ref cleanup support

* Added a new utility (`supportsRefCleanup` in `src/reactVersion.ts`) to detect if the current React version supports ref cleanup (i.e., React 19+), and updated all ref callback returns in `useInView` and `useOnInView` to only provide cleanup functions when supported. [[1]](diffhunk://#diff-49c813f2ef63ce6e00b366a7b9e759065dd5ceda5be7edd4dd1524fd5ea44911R1-R5) [[2]](diffhunk://#diff-cf264a9281c759897ca9a897636286bbf655c745b481880d138b9aa525e9b31dL3-R4) [[3]](diffhunk://#diff-841800710261c1afe81877f7dfe3bd8ea8861a43486e83dc11d940984934f1a0R7) [[4]](diffhunk://#diff-841800710261c1afe81877f7dfe3bd8ea8861a43486e83dc11d940984934f1a0L83-R100) [[5]](diffhunk://#diff-841800710261c1afe81877f7dfe3bd8ea8861a43486e83dc11d940984934f1a0L139-R145) [[6]](diffhunk://#diff-fd451bb0c61790c379841eb1dafbf603ead442695a17716d582610a5f07cf4bfR314-R316)

### Hook option handling and type consistency

* Changed `IntersectionEffectOptions` type to be identical to `IntersectionOptions`, allowing `useOnInView` to accept all the same options as `useInView`, including `initialInView` and `fallbackInView`.
* Updated the implementation of `useOnInView` to support `initialInView` and `fallbackInView` options, and ensured correct initial state handling and cleanup. [[1]](diffhunk://#diff-841800710261c1afe81877f7dfe3bd8ea8861a43486e83dc11d940984934f1a0R59-R73) [[2]](diffhunk://#diff-841800710261c1afe81877f7dfe3bd8ea8861a43486e83dc11d940984934f1a0L83-R100) [[3]](diffhunk://#diff-841800710261c1afe81877f7dfe3bd8ea8861a43486e83dc11d940984934f1a0R129) [[4]](diffhunk://#diff-841800710261c1afe81877f7dfe3bd8ea8861a43486e83dc11d940984934f1a0R155-R156)

### Refactoring and code simplification

* Refactored `useInView` to delegate intersection logic to `useOnInView`, simplifying its code and ensuring consistent option handling between the two hooks.

### Documentation updates

* Updated the documentation to clarify that `useOnInView` now only omits the `onChange` option, not `initialInView` or `fallbackInView`.

### Test improvements

* Updated tests to import React as a namespace and to use the new `supportsRefCleanup` utility for compatibility checks. [[1]](diffhunk://#diff-fd451bb0c61790c379841eb1dafbf603ead442695a17716d582610a5f07cf4bfL2-R8) [[2]](diffhunk://#diff-fd451bb0c61790c379841eb1dafbf603ead442695a17716d582610a5f07cf4bfR314-R316)