### PR TITLE
chore: update github actions

### DIFF
--- a/.github/workflows/pkg-pr.yml
+++ b/.github/workflows/pkg-pr.yml
@@ -1,20 +1,20 @@
 name: Publish Pull Requests
-on: [push, pull_request]
+on:
+  pull_request:
 
 jobs:
   pr-package:
     runs-on: ubuntu-latest
     steps:
-      - run: npm install --global corepack@latest
+      - uses: actions/checkout@v7
       - run: corepack enable
-      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: "pnpm"
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm build
       - name: Publish preview package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,22 +1,25 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-      - run: npm install --global corepack@latest
+      - uses: actions/checkout@v7
       - run: corepack enable
-      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: "pnpm"
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Install playwright
         run: pnpm exec playwright install
       - name: Lint
@@ -39,16 +42,15 @@ jobs:
           - 19
           - latest
     steps:
-      - run: npm install --global corepack@latest
+      - uses: actions/checkout@v7
       - run: corepack enable
-      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: "pnpm"
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Install legacy testing-library
         if: ${{  startsWith(matrix.react, '17') }}
         run: pnpm add -D @testing-library/react@12.1.4


### PR DESCRIPTION
## Summary

Update the GitHub Actions workflows for the Node 20 runner deprecation and reduce duplicate CI work on pull requests.

- Move official actions to current Node 24-compatible majors: `actions/checkout@v7` and `actions/setup-node@v6`
- Run workflow jobs on Node 24 explicitly
- Avoid duplicate test runs for PR branches by limiting `push` CI to `main` while keeping PR checks on `pull_request`
- Limit the package preview workflow to pull requests only
- Use frozen lockfile installs in CI
