### PR TITLE
docs: use private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,8 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability within the `react-intersection-observer` package or have any security concerns, 
-please [create a new issue](https://github.com/thebuilder/react-intersection-observer/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) on the Github repository. 
+If you discover a security vulnerability within the `react-intersection-observer` package or have any security concerns,
+please [submit a private vulnerability report](https://github.com/thebuilder/react-intersection-observer/security/advisories/new).
+Do not open a public issue for an undisclosed vulnerability.
 
 We appreciate your responsible disclosure.


### PR DESCRIPTION
## Summary

- direct security reports to GitHub private vulnerability reporting
- warn reporters not to disclose undisclosed vulnerabilities in public issues
- preserve the existing responsible-disclosure guidance

## Verification

- git diff --check origin/main..HEAD
- commit hook passed