### PR TITLE
fix: respect threshold before trigger once cleanup

### DIFF
--- a/src/__tests__/useInView.test.tsx
+++ b/src/__tests__/useInView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import React, { useCallback } from "react";
 import { defaultFallbackInView, type IntersectionOptions } from "../index";
 import {
@@ -139,12 +139,12 @@ test("should respect the threshold before triggering once", () => {
     time: performance.now(),
   });
 
-  React.act(() => callback([createEntry(0.25)], instance));
+  act(() => callback([createEntry(0.25)], instance));
 
   getByText("false");
   expect(instance.unobserve).not.toHaveBeenCalled();
 
-  React.act(() => callback([createEntry(0.5)], instance));
+  act(() => callback([createEntry(0.5)], instance));
 
   getByText("true");
   expect(instance.unobserve).toHaveBeenCalledTimes(1);

--- a/src/__tests__/useInView.test.tsx
+++ b/src/__tests__/useInView.test.tsx
@@ -118,6 +118,38 @@ test("should respect trigger once", () => {
   getByText("true");
 });
 
+test("should respect the threshold before triggering once", () => {
+  const { getByTestId, getByText } = render(
+    <HookComponent
+      options={{ initialInView: true, threshold: 0.5, triggerOnce: true }}
+    />,
+  );
+  const wrapper = getByTestId("wrapper");
+  const instance = intersectionMockInstance(wrapper);
+  const callback = vi.mocked(window.IntersectionObserver).mock.calls[0][0];
+  const createEntry = (
+    intersectionRatio: number,
+  ): IntersectionObserverEntry => ({
+    boundingClientRect: wrapper.getBoundingClientRect(),
+    intersectionRatio,
+    intersectionRect: wrapper.getBoundingClientRect(),
+    isIntersecting: true,
+    rootBounds: null,
+    target: wrapper,
+    time: performance.now(),
+  });
+
+  React.act(() => callback([createEntry(0.25)], instance));
+
+  getByText("false");
+  expect(instance.unobserve).not.toHaveBeenCalled();
+
+  React.act(() => callback([createEntry(0.5)], instance));
+
+  getByText("true");
+  expect(instance.unobserve).toHaveBeenCalledTimes(1);
+});
+
 test("should trigger onChange", () => {
   const onChange = vi.fn();
   render(<HookComponent options={{ onChange }} />);

--- a/src/useInView.tsx
+++ b/src/useInView.tsx
@@ -85,7 +85,7 @@ export function useInView({
           });
           if (callback.current) callback.current(inView, entry);
 
-          if (entry.isIntersecting && triggerOnce && unobserve) {
+          if (inView && triggerOnce && unobserve) {
             // If it should only trigger once, unobserve the element after it's inView
             unobserve();
             unobserve = undefined;


### PR DESCRIPTION
## Summary

- use the threshold-aware `inView` result before cleaning up a `triggerOnce` observer
- keep observing when the browser reports an intersection below the configured threshold
- add regression coverage for a below-threshold entry followed by an at-threshold entry

Fixes #756.

## Verification

- `corepack pnpm exec vitest run src/__tests__/useInView.test.tsx`
- `corepack pnpm exec vitest run`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec biome check src/useInView.tsx src/__tests__/useInView.test.tsx`
- `corepack pnpm build`
