### PR TITLE
fix: resume InView observation when triggerOnce is disabled

### DIFF
--- a/packages/react-intersection-observer/src/InView.tsx
+++ b/packages/react-intersection-observer/src/InView.tsx
@@ -91,6 +91,7 @@ export class InView extends React.Component<
       prevProps.scrollMargin !== this.props.scrollMargin ||
       prevProps.root !== this.props.root ||
       prevProps.threshold !== this.props.threshold ||
+      prevProps.triggerOnce !== this.props.triggerOnce ||
       prevProps.skip !== this.props.skip ||
       prevProps.trackVisibility !== this.props.trackVisibility ||
       prevProps.delay !== this.props.delay

--- a/packages/react-intersection-observer/src/__tests__/InView.test.tsx
+++ b/packages/react-intersection-observer/src/__tests__/InView.test.tsx
@@ -144,6 +144,34 @@ test("Should unobserve when triggerOnce comes into view", () => {
   expect(instance.unobserve).toHaveBeenCalled();
 });
 
+test("Should resume observing when triggerOnce is disabled", () => {
+  const callback = vi.fn();
+  const { rerender } = render(
+    <InView triggerOnce onChange={callback}>
+      Inner
+    </InView>,
+  );
+
+  mockAllIsIntersecting(true);
+  expect(callback).toHaveBeenLastCalledWith(
+    true,
+    expect.objectContaining({ isIntersecting: true }),
+  );
+
+  rerender(
+    <InView triggerOnce={false} onChange={callback}>
+      Inner
+    </InView>,
+  );
+  callback.mockClear();
+  mockAllIsIntersecting(false);
+
+  expect(callback).toHaveBeenLastCalledWith(
+    false,
+    expect.objectContaining({ isIntersecting: false }),
+  );
+});
+
 test("Should unobserve when unmounted", () => {
   const { container, unmount } = render(<InView triggerOnce>Inner</InView>);
   const instance = intersectionMockInstance(container.children[0]);

--- a/packages/react-intersection-observer/src/__tests__/InView.test.tsx
+++ b/packages/react-intersection-observer/src/__tests__/InView.test.tsx
@@ -144,32 +144,103 @@ test("Should unobserve when triggerOnce comes into view", () => {
   expect(instance.unobserve).toHaveBeenCalled();
 });
 
-test("Should resume observing when triggerOnce is disabled", () => {
+test("Should resume observing when triggerOnce is disabled while in view", () => {
   const callback = vi.fn();
-  const { rerender } = render(
+  const { container, rerender } = render(
     <InView triggerOnce onChange={callback}>
       Inner
     </InView>,
   );
+  const element = container.children[0];
+  const initialObserver = intersectionMockInstance(element);
+  vi.spyOn(initialObserver, "unobserve");
 
   mockAllIsIntersecting(true);
-  expect(callback).toHaveBeenLastCalledWith(
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenNthCalledWith(
+    1,
     true,
     expect.objectContaining({ isIntersecting: true }),
   );
+  expect(initialObserver.unobserve).toHaveBeenCalledWith(element);
 
+  callback.mockClear();
   rerender(
     <InView triggerOnce={false} onChange={callback}>
       Inner
     </InView>,
   );
-  callback.mockClear();
-  mockAllIsIntersecting(false);
+  const resumedObserver = intersectionMockInstance(element);
+  expect(resumedObserver).not.toBe(initialObserver);
 
-  expect(callback).toHaveBeenLastCalledWith(
+  // A fresh observer reports the element's current state.
+  mockAllIsIntersecting(true);
+  expect(callback).toHaveBeenNthCalledWith(
+    1,
+    true,
+    expect.objectContaining({ isIntersecting: true }),
+  );
+
+  mockAllIsIntersecting(false);
+  expect(callback).toHaveBeenNthCalledWith(
+    2,
     false,
     expect.objectContaining({ isIntersecting: false }),
   );
+
+  mockAllIsIntersecting(true);
+  expect(callback).toHaveBeenNthCalledWith(
+    3,
+    true,
+    expect.objectContaining({ isIntersecting: true }),
+  );
+  expect(callback).toHaveBeenCalledTimes(3);
+});
+
+test("Should stop observing when triggerOnce is enabled while in view", () => {
+  const callback = vi.fn();
+  const { container, rerender } = render(
+    <InView triggerOnce={false} onChange={callback}>
+      Inner
+    </InView>,
+  );
+  const element = container.children[0];
+  const initialObserver = intersectionMockInstance(element);
+  vi.spyOn(initialObserver, "unobserve");
+
+  mockAllIsIntersecting(true);
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenNthCalledWith(
+    1,
+    true,
+    expect.objectContaining({ isIntersecting: true }),
+  );
+
+  callback.mockClear();
+  rerender(
+    <InView triggerOnce onChange={callback}>
+      Inner
+    </InView>,
+  );
+  expect(initialObserver.unobserve).toHaveBeenCalledWith(element);
+
+  const triggerOnceObserver = intersectionMockInstance(element);
+  expect(triggerOnceObserver).not.toBe(initialObserver);
+  vi.spyOn(triggerOnceObserver, "unobserve");
+
+  // A fresh observer reports the element's current state before triggerOnce stops it.
+  mockAllIsIntersecting(true);
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenNthCalledWith(
+    1,
+    true,
+    expect.objectContaining({ isIntersecting: true }),
+  );
+  expect(triggerOnceObserver.unobserve).toHaveBeenCalledWith(element);
+
+  mockAllIsIntersecting(false);
+  mockAllIsIntersecting(true);
+  expect(callback).toHaveBeenCalledTimes(1);
 });
 
 test("Should unobserve when unmounted", () => {


### PR DESCRIPTION
Hi! I put together a small fix for the lifecycle behavior reported in #781,
along with a regression test.

## Summary

- resume observation in the class-based `<InView>` when `triggerOnce` changes
  from `true` to `false`
- add regression coverage for changing `triggerOnce` in both directions while
  the element is already visible

## Why

After the first intersecting entry, `handleChange()` invokes and clears the
stored `unobserve` callback when `triggerOnce` is enabled.

`componentDidUpdate()` already reinitializes observation when several
observer-related props change, but `triggerOnce` was not included in that
condition. As a result, changing only `triggerOnce` to `false` leaves the
mounted node unobserved until another relevant prop changes or the component is
remounted.

This change adds `triggerOnce` to the existing reinitialization condition. It
does not introduce a new API or a generic resubscribe mechanism.

Fixes #781

## Verification

- `CI=true pnpm test` — 7 files, 98 tests passed
- `CI=true pnpm --filter react-intersection-observer exec vitest --coverage` —
  98 tests passed
- `pnpm --filter react-intersection-observer typecheck`
- `pnpm biome ci .`
- `pnpm fallow audit --base upstream/main --coverage packages/react-intersection-observer/coverage/coverage-final.json`
- `pnpm build:all`

If runtime updates to `triggerOnce` are not intended for the class-based API, or
if you would prefer a different lifecycle behavior, I’d be happy to adjust the
approach. Thanks for taking a look!