### PR TITLE
docs: update public documentation domains

### DIFF
--- a/apps/docs/public/logo-horizontal.svg
+++ b/apps/docs/public/logo-horizontal.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="290" height="48" viewBox="0 0 290 48" fill="none">
+<svg id="light" xmlns="http://www.w3.org/2000/svg" width="290" height="48" viewBox="0 0 290 48" fill="none">
   <title>React Intersection Observer</title>
   <style>
     path[stroke="#000"] { stroke: currentColor; }
@@ -9,6 +9,11 @@
       path[stroke="#000"] { stroke: #f5f3ff; }
       path[fill="#1a1a1a"] { fill: #f5f3ff; }
     }
+
+    /* Storybook uses the #light fragment because its UI always uses the light
+       theme. Keep the wordmark dark even when the OS prefers a dark scheme. */
+    svg#light:target path[stroke="#000"] { stroke: #1a1a1a; }
+    svg#light:target path[fill="#1a1a1a"] { fill: #1a1a1a; }
   </style>
   <path stroke="#000" stroke-linecap="round" stroke-width="4" d="M5.25 21v-9.75c0-3.3 2.7-6 6-6h9m7.5 0h9c3.3 0 6 2.7 6 6v6m-37.5 10.5v9c0 3.3 2.7 6 6 6h6"/>
   <path fill="url(#a)" d="M37.5 22.5h-9a6 6 0 0 0-6 6v9a6 6 0 0 0 6 6h9a6 6 0 0 0 6-6v-9a6 6 0 0 0-6-6"/>

--- a/apps/storybook/.storybook/manager.ts
+++ b/apps/storybook/.storybook/manager.ts
@@ -5,7 +5,7 @@ import { storybookTheme } from "./theme";
 addons.setConfig({
   theme: {
     ...storybookTheme,
-    brandImage: docsLogo,
+    brandImage: `${docsLogo}#light`,
     brandTitle: "React Intersection Observer",
     brandUrl: "https://roi-storybook.thebuilder.dk/",
   },

--- a/apps/storybook/.storybook/manager.ts
+++ b/apps/storybook/.storybook/manager.ts
@@ -7,6 +7,6 @@ addons.setConfig({
     ...storybookTheme,
     brandImage: docsLogo,
     brandTitle: "React Intersection Observer",
-    brandUrl: "https://react-intersection-observer.vercel.app/",
+    brandUrl: "https://roi-storybook.thebuilder.dk/",
   },
 });

--- a/apps/storybook/stories/Intro.mdx
+++ b/apps/storybook/stories/Intro.mdx
@@ -4,4 +4,4 @@ A React implementation of the [Intersection Observer API](https://developer.mozi
 
 Use the stories in this library to explore the `InView` component, `useInView`, and `useOnInView` in isolation.
 
-For installation, API reference, guides, and recipes, visit the [documentation site](https://react-intersection-observer.vercel.app/).
+For installation, API reference, guides, and recipes, visit the [documentation site](https://react-intersection-observer.thebuilder.dk/).


### PR DESCRIPTION
## Summary
- point Storybook branding to roi-storybook.thebuilder.dk
- point the Storybook introduction to react-intersection-observer.thebuilder.dk
- keep the Storybook logo readable when the operating system prefers dark mode

## Verification
- pnpm --filter storybook lint
- pnpm --filter react-intersection-observer build
- pnpm --filter storybook build
- browser-verified in Storybook with dark OS preference