### PR TITLE
docs: cut filler from README and docs site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
-# Contribution Guidelines
+# Contribution guidelines
 
-Welcome to `react-intersection-observer`! I'm thrilled that you're interested in
-contributing. Here are some guidelines to help you get started.
+Thanks for wanting to contribute to `react-intersection-observer`. Here's what
+you need to know to get started.
 
 The codebase is written in TypeScript and uses PNPM workspaces:
 
@@ -12,22 +12,22 @@ The codebase is written in TypeScript and uses PNPM workspaces:
 
 ## Development
 
-Start by forking the repository, and after cloning it locally you can install
-the dependencies using [PNPM](https://pnpm.io/):
+Fork the repository, clone it locally, and install the dependencies with
+[PNPM](https://pnpm.io/):
 
 ```shell
 pnpm install
 ```
 
-Then you can start the development surfaces with the `dev` task:
+Then start both apps with the `dev` task:
 
 ```shell
 pnpm dev
 ```
 
-Use `pnpm dev:storybook` or `pnpm dev:docs` to start one surface at a time.
+Use `pnpm dev:storybook` or `pnpm dev:docs` to start one at a time.
 
-## Semantic Versioning
+## Semantic versioning
 
 `react-intersection-observer` follows Semantic Versioning 2.0 as defined at
 http://semver.org. This means that releases will be numbered with the following
@@ -39,52 +39,47 @@ format:
 - Backwards-compatible enhancements will increment the minor version.
 - Bug fixes and documentation changes will increment the patch version.
 
-## Pull Request Process
+## Pull requests
 
-Fork the repository and create a branch for your feature/bug fix.
+Create a branch on your fork for the fix or feature, then:
 
-- Add tests for your feature/bug fix.
-- Ensure that all tests pass before submitting your pull request.
-- Update the README.md file if necessary.
-- Ensure that your commits follow the conventions outlined in the next section.
+- Add tests for the change.
+- Make sure all tests pass.
+- Update `README.md` if the change affects it.
+- Follow the commit conventions below.
 
-### Commit Message Conventions
+### Commit message conventions
 
-- We follow the
-  [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-  Conventions, so the generated release notes stay readable. This means that
-  your commit messages should have the following format:
+Commits follow
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), so the
+generated release notes stay readable:
 
 `<type>: <subject>`
 
-Here's what each part of the commit message means:
+- `<type>` is the kind of change. Use `feat` for new features, `fix` for bug
+  fixes, `docs` for documentation, and `chore` for everything that doesn't touch
+  the code itself, such as dependency updates.
+- `<subject>` is a short description of the change.
 
-- `<type>`: The type of change that you're committing. Valid types include
-  `feat` for new features, `fix` for bug fixes, `docs` for documentation
-  changes, and `chore` for changes that don't affect the code itself (e.g.
-  updating dependencies).
-- `<subject>`: A short description of the change.
+### Code style and linting
 
-### Code Style and Linting
-
-`react-intersection-observer` uses [Biome](https://biomejs.dev/) for code
-formatting and linting. Please ensure that your changes are formatted with Biome before
-submitting your pull request.
+`react-intersection-observer` uses [Biome](https://biomejs.dev/) for formatting
+and linting. Format your changes with Biome before opening a pull request.
 
 ### Testing
 
 `react-intersection-observer` uses [Vitest](https://vitest.dev/) for testing.
-Please ensure that your changes are covered by tests, and that all tests pass
-before submitting your pull request.
+Cover your changes with tests, and make sure the whole suite passes before
+opening a pull request.
 
-You can run the package tests with the `test` task. Component tests run in
-Vitest Browser Mode with Playwright; SSR tests run in a separate Node project.
+Run the package tests with the `test` task. Component tests run in Vitest
+Browser Mode with Playwright, and SSR tests run in a separate Node project.
 
 ```shell
 pnpm test
 ```
 
-Build every published and documentation surface with:
+Build the package and both apps with:
 
 ```shell
 pnpm build:all
@@ -107,6 +102,6 @@ The workflow bumps the version, commits and tags it, builds the package,
 publishes it to npm, and creates a GitHub release with generated notes.
 
 `main` is protected, so the version commit is pushed with a short-lived token
-minted from a GitHub App that is listed as a bypass actor on the branch
-ruleset. The app's id lives in the `RELEASE_APP_ID` variable and its private key
-in the `RELEASE_APP_KEY` secret.
+minted from a GitHub App listed as a bypass actor on the branch ruleset. The
+app's id lives in the `RELEASE_APP_ID` variable, and its private key in the
+`RELEASE_APP_KEY` secret.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 ![npm package minimized gzipped size](https://img.shields.io/bundlejs/size/react-intersection-observer?exports=InView%2C%20useOnInView%2C%20useInView&externals=react&format=both)
 
 A React implementation of the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
-that tells you when an element enters or leaves the viewport. It ships
+that tells you when an element enters or leaves the viewport. Use it for scroll
+animations, lazy loading, impression tracking, and infinite scroll. It ships
 [hooks](#useinview-hook), [render props](#render-props), and
 [plain children](#plain-children).
 

--- a/README.md
+++ b/README.md
@@ -8,29 +8,28 @@
 [![Downloads](http://img.shields.io/npm/dm/react-intersection-observer.svg)](http://npm-stat.com/charts.html?package=react-intersection-observer)
 ![npm package minimized gzipped size](https://img.shields.io/bundlejs/size/react-intersection-observer?exports=InView%2C%20useOnInView%2C%20useInView&externals=react&format=both)
 
-A React implementation of the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) 
-to tell you when an element enters or leaves the viewport. Contains [Hooks](#useinview-hook), [render props](#render-props), and [plain children](#plain-children) implementations.
+A React implementation of the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
+that tells you when an element enters or leaves the viewport. It ships
+[hooks](#useinview-hook), [render props](#render-props), and
+[plain children](#plain-children).
 
 ## Features
 
-- 🪝 **Hooks or Component API** - With `useInView` and `useOnInView` it's easier
-  than ever to monitor elements
-- ⚡️ **Optimized performance** - Reuses Intersection Observer instances where
-  possible
-- ⚙️ **Matches native API** - Intuitive to use
-- 🛠 **Written in TypeScript** - It'll fit right into your existing TypeScript
-  project
-- 🧪 **Ready to test** - Mocks the Intersection Observer for easy testing with
-  [Jest](https://jestjs.io/) or [Vitest](https://vitest.dev/)
-- 🌳 **Tree-shakeable** - Only include the parts you use
-- 💥 **Tiny bundle** - Around **~1.15kB** for `useInView` and **~1.6kB** for
-  `<InView>`
+- **Hooks or component API** - `useInView` for React state, `useOnInView` for
+  callbacks, `<InView>` for render props and wrapper elements.
+- **Shared observers** - Observers with matching options are reused, so watching
+  many elements stays cheap.
+- **Matches the native API** - Options map straight to
+  `IntersectionObserverInit`.
+- **Written in TypeScript** - Types ship with the package.
+- **Ready to test** - Mocks the Intersection Observer for
+  [Jest](https://jestjs.io/) and [Vitest](https://vitest.dev/).
+- **Tree-shakeable** - Only the parts you import end up in your bundle.
+- **Small** - Around 1.15kB gzipped for `useInView`, 1.6kB for `<InView>`.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/thebuilder/react-intersection-observer)
 
 ## Installation
-
-Install the package with your package manager of choice:
 
 ```sh
 npm install react-intersection-observer --save
@@ -48,13 +47,11 @@ const { ref, inView, entry } = useInView(options);
 const [ref, inView, entry] = useInView(options);
 ```
 
-The `useInView` hook makes it easy to monitor the `inView` state of your
-components. Call the `useInView` hook with the (optional) [options](#options)
-you need. It will return an array containing a `ref`, the `inView` status and
-the current
+Call `useInView` with the (optional) [options](#options) you need. It returns a
+`ref`, the `inView` status, and the current
 [`entry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry).
-Assign the `ref` to the DOM element you want to monitor, and the hook will
-report the status.
+Assign the `ref` to the DOM element you want to watch, and the hook reports the
+status.
 
 ```jsx
 import React from "react";
@@ -92,23 +89,22 @@ const inViewRef = useOnInView(
 );
 ```
 
-The `useOnInView` hook provides a more direct alternative to `useInView`. It
-takes a callback function and returns a ref that you can assign to the DOM
-element you want to monitor. Whenever the element enters or leaves the viewport,
-your callback will be triggered with the latest in-view state.
+`useOnInView` takes a callback and returns a ref to assign to the DOM element
+you want to watch. Whenever the element enters or leaves the viewport, the
+callback runs with the latest in-view state.
 
-Key differences from `useInView`:
-- **No re-renders** - This hook doesn't update any state, making it ideal for
-  performance-critical scenarios
-- **Direct element access** - Your callback receives the actual
-  IntersectionObserverEntry with the `target` element
-- **Boolean-first callback** - The callback receives the current `inView`
-  boolean as the first argument, matching the `onChange` signature from
-  `useInView`
-- **Similar options** - Accepts all the same [options](#options) as `useInView`
-  except `onChange`, `initialInView`, and `fallbackInView`
+Differences from `useInView`:
 
-> **Note:** Just like `useInView`, the initial `false` notification is skipped. Your callback fires the first time the element becomes visible (and on every subsequent enter/leave transition).
+- **No re-renders** - The hook holds no state, so a visibility change never
+  triggers a render.
+- **Direct element access** - The callback receives the
+  `IntersectionObserverEntry`, including the `target` element.
+- **Boolean-first callback** - The first argument is the current `inView`
+  boolean, matching the `onChange` signature from `useInView`.
+- **Same options** - Accepts every [option](#options) `useInView` does, except
+  `onChange`, `initialInView`, and `fallbackInView`.
+
+> **Note:** Just like `useInView`, the initial `false` notification is skipped. Your callback fires the first time the element becomes visible, then on every enter and leave transition after that.
 
 ```jsx
 import React from "react";
@@ -119,7 +115,7 @@ const Component = () => {
   const trackingRef = useOnInView(
     (inView, entry) => {
       if (inView) {
-        // Element is in view - perhaps log an impression
+        // Element is in view, so log an impression
         console.log("Element appeared in view", entry.target);
       } else {
         console.log("Element left view", entry.target);
@@ -142,23 +138,21 @@ const Component = () => {
 
 ### Render props
 
-To use the `<InView>` component, you pass it a function. It will be called
-whenever the state changes, with the new value of `inView`. In addition to the
-`inView` prop, children also receive a `ref` that should be set on the
-containing DOM element. This is the element that the Intersection Observer will
-monitor.
+Pass `<InView>` a function. It runs whenever the state changes, with the new
+value of `inView`. Children also receive a `ref` that you set on the containing
+DOM element. That element is the one the Intersection Observer watches.
 
-If you need it, you can also access the
+The
 [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry)
-on `entry`, giving you access to all the details about the current intersection
+is available on `entry` when you need the details of the current intersection
 state.
 
 ```jsx
 import { InView } from "react-intersection-observer";
 
- const Component = () => (
- <InView>
- {({ inView, ref, entry }) => (
+const Component = () => (
+  <InView>
+    {({ inView, ref, entry }) => (
       <div ref={ref}>
         <h2>{`Header inside viewport ${inView}.`}</h2>
       </div>
@@ -166,17 +160,17 @@ import { InView } from "react-intersection-observer";
   </InView>
 );
 
- export default Component;
- ```
+export default Component;
+```
 
-> **Note:** `<InView>` mirrors the hook behaviour—it suppresses the very first `false` notification so render props and `onChange` handlers only run after a genuine visibility change.
+> **Note:** `<InView>` behaves like the hooks. It suppresses the first `false` notification, so render props and `onChange` handlers only run after a real visibility change.
 
 ### Plain children
 
-You can pass any element to the `<InView />`, and it will handle creating the
-wrapping DOM element. Add a handler to the `onChange` method, and control the
-state in your own component. Any extra props you add to `<InView>` will be
-passed to the HTML element, allowing you set the `className`, `style`, etc.
+Pass any element to `<InView />` and it creates the wrapping DOM element for
+you. Add a handler to `onChange` and keep the state in your own component. Extra
+props on `<InView>` go to the HTML element, so you can set `className`, `style`,
+and the rest.
 
 ```jsx
 import { InView } from "react-intersection-observer";
@@ -191,54 +185,52 @@ export default Component;
 ```
 
 > [!NOTE]
-> When rendering a plain child, make sure you keep your HTML output
-> semantic. Change the `as` to match the context, and add a `className` to style
-> the `<InView />`. The component does not support Ref Forwarding, so if you
-> need a `ref` to the HTML element, use the Render Props version instead.
+> When rendering a plain child, keep your HTML output semantic. Change `as` to
+> match the context, and add a `className` to style the `<InView />`. The
+> component does not forward refs, so use the render props version if you need a
+> `ref` to the HTML element.
 
 ## API
 
 ### Options
 
-Provide these as the options argument in the `useInView` hook or as props on the
-**`<InView />`** component.
+Pass these as the options argument to `useInView`, or as props on `<InView />`.
 
 | Name                   | Type                      | Default     | Description                                                                                                                                                                                                                                                                                     |
 | ---------------------- | ------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **root**               | `Element`                 | `document`  | The Intersection Observer interface's read-only root property identifies the Element or Document whose bounds are treated as the bounding box of the viewport for the element which is the observer's target. If the root is `null`, then the bounds of the actual document viewport are used.  |
+| **root**               | `Element`                 | `document`  | The element whose bounds count as the viewport for the target. It must be an ancestor of the target. With `null`, the document viewport is used.                                                                                                                                                 |
 | **rootMargin**         | `string`                  | `'0px'`     | Margin around the root. Can have values similar to the CSS margin property, e.g. `"10px 20px 30px 40px"` (top, right, bottom, left). Also supports percentages, to check if an element intersects with the center of the viewport for example `"-50% 0% -50% 0%"`.                              |
 | **scrollMargin**       | `string`                  | `'0px'`     | Margin around nested scroll containers that clip the target. Can have values similar to the CSS margin property, e.g. `"10px 20px 30px 40px"` (top, right, bottom, left). Unlike `rootMargin`, this grows or shrinks every scroll container's clipping rectangle within the root, including the root itself if it is a scroll container.                              |
 | **threshold**          | `number` or `number[]`    | `0`         | Number between `0` and `1` indicating the percentage that should be visible before triggering. Can also be an array of numbers, to create multiple trigger points.                                                                                                                              |
-| **onChange**           | `(inView, entry) => void` | `undefined` | Call this function whenever the in view state changes. It will receive the `inView` boolean, alongside the current `IntersectionObserverEntry`.                                                                                                                                                 |
-| **trackVisibility** 🧪 | `boolean`                 | `false`     | A boolean indicating whether this Intersection Observer will track visibility changes on the target.                                                                                                                                                                                            |
-| **delay** 🧪           | `number`                  | `undefined` | A number indicating the minimum delay in milliseconds between notifications from this observer for a given target. This must be set to at least `100` if `trackVisibility` is `true`.                                                                                                           |
-| **skip**               | `boolean`                 | `false`     | Skip creating the IntersectionObserver. You can use this to enable and disable the observer as needed. If `skip` is set while `inView`, the current state will still be kept.                                                                                                                   |
+| **onChange**           | `(inView, entry) => void` | `undefined` | Runs whenever the in view state changes, with the `inView` boolean and the current `IntersectionObserverEntry`.                                                                                                                                                                                  |
+| **trackVisibility**    | `boolean`                 | `false`     | Experimental. Track visibility changes on the target, beyond plain intersection. See [Intersection Observer v2](#intersection-observer-v2).                                                                                                                                                          |
+| **delay**              | `number`                  | `undefined` | Experimental. Minimum delay in milliseconds between notifications for a given target. Must be at least `100` if `trackVisibility` is `true`.                                                                                                                                                     |
+| **skip**               | `boolean`                 | `false`     | Skip creating the IntersectionObserver, so you can turn observation on and off. Setting `skip` while `inView` keeps the current state.                                                                                                                                                           |
 | **triggerOnce**        | `boolean`                 | `false`     | Only trigger the observer once.                                                                                                                                                                                                                                                                 |
-| **initialInView**      | `boolean`                 | `false`     | Set the initial value of the `inView` boolean. This can be used if you expect the element to be in the viewport to start with, and you want to trigger something when it leaves.                                                                                                                |
-| **fallbackInView**     | `boolean`                 | `undefined` | If the `IntersectionObserver` API isn't available in the client, the default behavior is to throw an Error. You can set a specific fallback behavior, and the `inView` value will be set to this instead of failing. To set a global default, you can set it with the `defaultFallbackInView()` |
+| **initialInView**      | `boolean`                 | `false`     | The starting value of `inView`. Set it to `true` when the element starts in the viewport and you want to trigger something when it leaves.                                                                                                                                                       |
+| **fallbackInView**     | `boolean`                 | `undefined` | The `inView` value to use when the client has no `IntersectionObserver`, instead of the default behavior of throwing. `defaultFallbackInView()` sets this globally.                                                                                                                              |
 
 `useOnInView` accepts the same options as `useInView` except `onChange`,
 `initialInView`, and `fallbackInView`.
 
-### InView Props
+### InView props
 
 The **`<InView />`** component also accepts the following props:
 
 | Name         | Type                                                 | Default     | Description                                                                                                                                                                                                                                                                                                                    |
 | ------------ | ---------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **as**       | `IntrinsicElement`                                   | `'div'`     | Render the wrapping element as this element. Defaults to `div`. If you want to use a custom component, please use the `useInView` hook or a render prop instead to manage the reference explictly.                                                                                                                             |
-| **children** | `({ref, inView, entry}) => ReactNode` or `ReactNode` | `undefined` | Children expects a function that receives an object containing the `inView` boolean and a `ref` that should be assigned to the element root. Alternatively pass a plain child, to have the `<InView />` deal with the wrapping element. You will also get the `IntersectionObserverEntry` as `entry`, giving you more details. |
+| **as**       | `IntrinsicElement`                                   | `'div'`     | Render the wrapping element as this element. Defaults to `div`. If you want to use a custom component, use the `useInView` hook or a render prop instead to manage the reference explicitly.                                                                                                                             |
+| **children** | `({ref, inView, entry}) => ReactNode` or `ReactNode` | `undefined` | A function receiving `inView`, a `ref` to assign to the element root, and the `IntersectionObserverEntry` as `entry`. Pass a plain child instead to let `<InView />` create the wrapping element.                                                                                                |
 
-### Intersection Observer v2 🧪
+### Intersection Observer v2
 
-The new
-[v2 implementation of IntersectionObserver](https://developers.google.com/web/updates/2019/02/intersectionobserver-v2)
-extends the original API, so you can track if the element is covered by another
-element or has filters applied to it. Useful for blocking clickjacking attempts
-or tracking ad exposure.
+[Intersection Observer v2](https://developers.google.com/web/updates/2019/02/intersectionobserver-v2)
+extends the original API, so you can track whether the element is covered by
+another element or has filters applied to it. Useful for blocking clickjacking
+attempts or tracking ad exposure.
 
-To use it, you'll need to add the new `trackVisibility` and `delay` options.
-When you get the `entry` back, you can then monitor if `isVisible` is `true`.
+Add the `trackVisibility` and `delay` options, then check whether `isVisible`
+is `true` on the `entry` you get back.
 
 ```jsx
 const TrackVisible = () => {
@@ -247,18 +239,16 @@ const TrackVisible = () => {
 };
 ```
 
-This is still a very new addition, so check
-[caniuse](https://caniuse.com/#feat=intersectionobserver-v2) for current browser
-support. If `trackVisibility` has been set, and the current browser doesn't
-support it, a fallback has been added to always report `isVisible` as `true`.
+Check [caniuse](https://caniuse.com/#feat=intersectionobserver-v2) for current
+browser support. If you set `trackVisibility` and the browser doesn't support
+it, the fallback always reports `isVisible` as `true`.
 
-It's not added to the TypeScript `lib.d.ts` file yet, so you will also have to
-extend the `IntersectionObserverEntry` with the `isVisible` boolean.
+`isVisible` isn't in the TypeScript `lib.d.ts` file yet, so you also have to
+extend `IntersectionObserverEntry` with the boolean yourself.
 
 ## Recipes
 
-The `IntersectionObserver` itself is just a simple but powerful tool. Here's a
-few ideas for how you can use it.
+A few things you can build with it:
 
 - [Lazy image load](apps/docs/docs/guides/recipes.mdx#lazy-image-loading)
 - [Trigger animations](apps/docs/docs/guides/recipes.mdx#scroll-triggered-animation)
@@ -282,9 +272,9 @@ function Component(props) {
   // Use `useCallback` so we don't recreate the function on each render
   const setRefs = useCallback(
     (node) => {
-      // Ref's from useRef needs to have the node assigned to `current`
+      // Refs from `useRef` need the node assigned to `current`
       ref.current = node;
-      // Callback refs, like the one from `useInView`, is a function that takes the node as an argument
+      // Callback refs, like the one from `useInView`, are functions that take the node
       inViewRef(node);
     },
     [inViewRef],
@@ -296,15 +286,13 @@ function Component(props) {
 
 ### `rootMargin` isn't working as expected
 
-When using `rootMargin`, the margin gets added to the current `root` - If your
-application is running inside a `<iframe>`, or you have defined a custom `root`
-this will not be the current viewport.
+`rootMargin` is added to the current `root`. If your application runs inside an
+`<iframe>`, or you defined a custom `root`, that root is not the viewport.
 
-If the target is clipped by a scrollable container inside the `root`, use
-`scrollMargin` to change when intersections are calculated for that nested
-scroll container.
+If a scrollable container inside the `root` clips the target, use `scrollMargin`
+to change when intersections are calculated for that nested scroll container.
 
-You can read more about this on these links:
+More background:
 
 - [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#The_intersection_root_and_root_margin)
 - [IntersectionObserver scrollMargin](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/scrollMargin)
@@ -316,42 +304,39 @@ You can read more about this on these links:
 
 > [!TIP]
 > Consider using [Vitest Browser Mode](https://vitest.dev/guide/browser/) instead of `jsdom` or `happy-dom`.
-> This option allows you to utilize the real browser implementation and triggers correctly when scrolling or adding elements to the viewport. You can skip the `react-intersection-observer/test-utils`, or use it as needed.
+> It runs the browser's own implementation, so intersections trigger correctly when you scroll or add elements to the viewport. You can skip `react-intersection-observer/test-utils` there, or use it where you need it.
 
-In order to write meaningful tests, the `IntersectionObserver` needs to be
-mocked. You can use the included `react-intersection-observer/test-utils` to
-help with this. It mocks the `IntersectionObserver`, and includes a few methods
-to assist with faking the `inView` state. When setting the `isIntersecting`
-value you can pass either a `boolean` value or a threshold between 0 and 1. It
-will emulate the real IntersectionObserver, allowing you to validate that your
-components are behaving as expected.
+To write meaningful tests, mock the `IntersectionObserver`. The included
+`react-intersection-observer/test-utils` does that, and adds a few methods for
+faking the `inView` state. Pass `isIntersecting` either a `boolean` or a
+threshold between 0 and 1; the mock emulates the real IntersectionObserver so
+you can check that your components behave as expected.
 
 | Method                                        | Description                                                                                                                                                                       |
 |-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `mockAllIsIntersecting(isIntersecting)`       | Set `isIntersecting` on all current Intersection Observer instances. The value of `isIntersecting` should be either a `boolean` or a threshold between 0 and 1.                   |
-| `mockIsIntersecting(element, isIntersecting)` | Set `isIntersecting` for the Intersection Observer of a specific `element`. The value of `isIntersecting` should be either a `boolean` or a threshold between 0 and 1.            |
-| `intersectionMockInstance(element)`           | Call the `intersectionMockInstance` method with an element, to get the (mocked) `IntersectionObserver` instance. You can use this to spy on the `observe` and`unobserve` methods. |
-| `setupIntersectionMocking(mockFn)`            | Mock the `IntersectionObserver`, so we can interact with them in tests - Should be called in `beforeEach`. (**Done automatically in Jest environment**)                           |
-| `resetIntersectionMocking()`                  | Reset the mocks on `IntersectionObserver` - Should be called in `afterEach`. (**Done automatically in Jest/Vitest environment**)                                                  |
-| `destroyIntersectionMocking()`                | Destroy the mocked `IntersectionObserver` function, and return `window.IntersectionObserver` to the original browser implementation                                               |
+| `mockAllIsIntersecting(isIntersecting)`       | Set `isIntersecting` on every current Intersection Observer instance. Pass a `boolean` or a threshold between 0 and 1.                                                            |
+| `mockIsIntersecting(element, isIntersecting)` | Set `isIntersecting` for the Intersection Observer of one `element`. Pass a `boolean` or a threshold between 0 and 1.                                                             |
+| `intersectionMockInstance(element)`           | Get the mocked `IntersectionObserver` instance for an element, so you can spy on its `observe` and `unobserve` methods.                                                           |
+| `setupIntersectionMocking(mockFn)`            | Mock the `IntersectionObserver`. Call it in `beforeEach`. (Happens automatically in a Jest environment.)                                                                          |
+| `resetIntersectionMocking()`                  | Reset the mocks on `IntersectionObserver`. Call it in `afterEach`. (Happens automatically in a Jest or Vitest environment.)                                                       |
+| `destroyIntersectionMocking()`                | Destroy the mock and restore the browser's own `window.IntersectionObserver`.                                                                                                     |
 
-### Testing Libraries
+### Testing libraries
 
-This library comes with built-in support for writing tests in both
-[Jest](https://jestjs.io/) and [Vitest](https://vitest.dev/)
+The test utilities work with both [Jest](https://jestjs.io/) and
+[Vitest](https://vitest.dev/).
 
 #### Jest
 
-Testing with Jest should work out of the box. Just import the
-`react-intersection-observer/test-utils` in your test files, and you can use the
-mocking methods.
+Jest works out of the box. Import `react-intersection-observer/test-utils` in
+your test files and use the mocking methods.
 
 #### Vitest
 
-If you're running Vitest with [globals](https://vitest.dev/config/#globals),
-then it'll automatically mock the IntersectionObserver, just like running with
-Jest. Otherwise, you'll need to manually setup/reset the mocking in either the
-individual tests, or a [setup file](https://vitest.dev/config/#setupfiles).
+With Vitest [globals](https://vitest.dev/config/#globals) enabled, the
+IntersectionObserver is mocked automatically, just like in Jest. Otherwise, set
+up and reset the mocking yourself, either in individual tests or in a
+[setup file](https://vitest.dev/config/#setupfiles).
 
 ```js
 import { vi, beforeEach, afterEach } from "vitest";
@@ -369,34 +354,35 @@ afterEach(() => {
 });
 ```
 
-You only need to do this if the test environment does not support `beforeEach`
-globally, alongside either `jest.fn` or `vi.fn`.
+You only need this if the test environment doesn't expose `beforeEach` globally
+alongside either `jest.fn` or `vi.fn`.
 
-#### Other Testing Libraries
+#### Other testing libraries
 
-See the instructions for [Vitest](#vitest). You should be able to use a similar
-setup/reset code, adapted to the testing library you are using. Failing that,
-copy the code from [test-utils.ts](packages/react-intersection-observer/src/test-utils.ts), and make your own version.
+Follow the [Vitest](#vitest) instructions. The same setup and reset code should
+work, adapted to your test runner. Failing that, copy
+[test-utils.ts](packages/react-intersection-observer/src/test-utils.ts) and make
+your own version.
 
-### Fallback Behavior
+### Fallback behavior
 
 You can create a
 [Jest setup file](https://jestjs.io/docs/configuration#setupfilesafterenv-array)
-that leverages the
+that uses the
 [unsupported fallback](https://github.com/thebuilder/react-intersection-observer#unsupported-fallback)
-option. In this case, you can override the `IntersectionObserver` in test files
-were you actively import `react-intersection-observer/test-utils`.
+option, then override the `IntersectionObserver` in the test files where you
+import `react-intersection-observer/test-utils`.
 
 **test-setup.js**
 
 ```js
 import { defaultFallbackInView } from "react-intersection-observer";
 
-defaultFallbackInView(true); // or `false` - whichever consistent behavior makes the most sense for your use case.
+defaultFallbackInView(true); // or `false`, whichever is right for your app
 ```
 
-Alternatively, you can mock the Intersection Observer in all tests with a global
-setup file. Add `react-intersection-observer/test-utils` to
+To mock the Intersection Observer in every test instead, use a global setup
+file. Add `react-intersection-observer/test-utils` to
 [setupFilesAfterEnv](https://jestjs.io/docs/configuration#setupfilesafterenv-array)
 in the Jest config, or [setupFiles](https://vitest.dev/config/#setupfiles) in
 Vitest.
@@ -407,7 +393,7 @@ module.exports = {
 };
 ```
 
-### Test Example
+### Test example
 
 ```js
 import React from "react";
@@ -447,7 +433,7 @@ test("should create a hook inView with threshold", () => {
   screen.getByText("true");
 });
 
-test("should mock intersecing on specific hook", () => {
+test("should mock intersecting on a specific hook", () => {
   render(<HookComponent />);
   const wrapper = screen.getByTestId("wrapper");
 
@@ -469,24 +455,20 @@ test("should create a hook and call observe", () => {
 ## Intersection Observer
 
 [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
-is the API used to determine if an element is inside the viewport or not.
-[Browser support is excellent](http://caniuse.com/#feat=intersectionobserver) -
-With
-[Safari adding support in 12.1](https://webkit.org/blog/8718/new-webkit-features-in-safari-12-1/),
-all major browsers now support Intersection Observers natively. Add the
-polyfill, so it doesn't break on older versions of iOS and IE11.
+is the API used to determine whether an element is inside the viewport. Every
+major browser
+[supports it natively](http://caniuse.com/#feat=intersectionobserver), Safari
+[since 12.1](https://webkit.org/blog/8718/new-webkit-features-in-safari-12-1/).
+Add the polyfill if you still support older iOS versions or IE11.
 
 ### Unsupported fallback
 
-If the client doesn't have support for the `IntersectionObserver`, then the
-default behavior is to throw an error. This will crash the React application,
-unless you capture it with an Error Boundary.
+If the client has no `IntersectionObserver`, the default behavior is to throw an
+error. That crashes the React application unless an Error Boundary catches it.
 
-If you prefer, you can set a fallback `inView` value to use if the
-`IntersectionObserver` doesn't exist. This will make
-`react-intersection-observer` fail gracefully, but you must ensure your
-application can correctly handle all your observers firing either `true` or
-`false` at the same time.
+You can instead set a fallback `inView` value to use when
+`IntersectionObserver` doesn't exist. Make sure your application handles every
+observer firing `true` (or `false`) at the same time.
 
 You can set the fallback globally:
 
@@ -496,8 +478,8 @@ import { defaultFallbackInView } from "react-intersection-observer";
 defaultFallbackInView(true); // or 'false'
 ```
 
-You can also define the fallback locally on `useInView` or `<InView>` as an
-option. This will override the global fallback value.
+You can also set the fallback locally on `useInView` or `<InView>`. A local
+value overrides the global one.
 
 ```jsx
 import React from "react";
@@ -518,10 +500,10 @@ const Component = () => {
 
 ### Polyfill
 
-You can import the
-[polyfill](https://www.npmjs.com/package/intersection-observer) directly or use
-a service like [https://cdnjs.cloudflare.com/polyfill](https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js) to add it when
-needed.
+Import the [polyfill](https://www.npmjs.com/package/intersection-observer)
+directly, or use a service like
+[cdnjs.cloudflare.com/polyfill](https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js)
+to add it when needed.
 
 ```sh
 yarn add intersection-observer
@@ -533,14 +515,13 @@ Then import it in your app:
 import "intersection-observer";
 ```
 
-If you are using Webpack (or similar) you could use
-[dynamic imports](https://webpack.js.org/api/module-methods/#dynamic-expressions-in-import),
-to load the Polyfill only if needed. A basic implementation could look something
-like this:
+With Webpack or a similar bundler, use
+[dynamic imports](https://webpack.js.org/api/module-methods/#dynamic-expressions-in-import)
+to load the polyfill only when it's needed:
 
 ```js
 /**
- * Do feature detection, to figure out which polyfills needs to be imported.
+ * Feature detection, to figure out which polyfills need importing.
  **/
 async function loadPolyfills() {
   if (typeof window.IntersectionObserver === "undefined") {
@@ -549,12 +530,12 @@ async function loadPolyfills() {
 }
 ```
 
-## Low level API
+## Low-level API
 
-You can access the [`observe`](src/observe.ts) method, that
+The [`observe`](src/observe.ts) method is the one
 `react-intersection-observer` uses internally to create and destroy
-IntersectionObserver instances. This allows you to handle more advanced use
-cases, where you need full control over when and how observers are created.
+IntersectionObserver instances. Use it when you need full control over when and
+how observers are created.
 
 ```js
 import { observe } from "react-intersection-observer";
@@ -568,10 +549,10 @@ const destroy = observe(element, callback, options);
 | **callback** | `ObserverInstanceCallback` | true     | The callback function that Intersection Observer will call |
 | **options**  | `IntersectionObserverInit` | false    | The options for the Intersection Observer                  |
 
-The `observe` method returns an `unobserve` function, that you must call in
-order to destroy the observer again.
+`observe` returns an `unobserve` function. Call it to destroy the observer
+again.
 
 > [!IMPORTANT]
-> You most likely won't need this, but it can be useful if you
-> need to handle IntersectionObservers outside React, or need full control over
-> how instances are created.
+> You most likely won't need this. It's here for handling
+> IntersectionObservers outside React, or when you need full control over how
+> instances are created.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,9 @@
-# Security Policy
+# Security policy
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
-If you discover a security vulnerability within the `react-intersection-observer` package or have any security concerns,
-please [submit a private vulnerability report](https://github.com/thebuilder/react-intersection-observer/security/advisories/new).
+Found a security vulnerability in the `react-intersection-observer` package, or have a security concern?
+[Submit a private vulnerability report](https://github.com/thebuilder/react-intersection-observer/security/advisories/new).
 Do not open a public issue for an undisclosed vulnerability.
 
-We appreciate your responsible disclosure.
+Thanks for disclosing it responsibly.

--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -5,7 +5,7 @@ import { githubReleaseChangelogSource } from "./sources/github-releases";
 export default defineConfig({
   title: "React Intersection Observer",
   description:
-    "A lightweight React implementation of the Intersection Observer API.",
+    "React hooks and components for the Intersection Observer API. Know when an element enters or leaves the viewport.",
   logo: {
     image: "/logo-horizontal.svg",
     // The horizontal mark already carries the wordmark, so hide the extra text

--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -5,7 +5,7 @@ import { githubReleaseChangelogSource } from "./sources/github-releases";
 export default defineConfig({
   title: "React Intersection Observer",
   description:
-    "React hooks and components for the Intersection Observer API. Know when an element enters or leaves the viewport.",
+    "React hooks and components for the Intersection Observer API. Scroll animations, lazy loading, impressions, and infinite scroll.",
   logo: {
     image: "/logo-horizontal.svg",
     // The horizontal mark already carries the wordmark, so hide the extra text

--- a/apps/docs/docs/api/configuration.mdx
+++ b/apps/docs/docs/api/configuration.mdx
@@ -53,7 +53,7 @@ export function ScrollArea() {
 }
 ```
 
-`scrollMargin` is not a substitute for `rootMargin`. It only affects nested scroll containers inside the root, as in `useInView({ root, scrollMargin: "80px 0px" })`. Watch out for the things that quietly change what the browser considers visible: invalid margin syntax, thresholds outside `0` to `1`, iframes, and custom roots.
+When an inner scroller clips the target, add `scrollMargin`, as in `useInView({ root, scrollMargin: "80px 0px" })`. Watch out for the things that quietly change what the browser considers visible: invalid margin syntax, thresholds outside `0` to `1`, iframes, and custom roots.
 
 :::note[Verify configuration]
 Test real layout, scrolling, and geometry in [Vitest Browser Mode](/testing/browser-mode). To cross a configured threshold without depending on layout, use a deterministic mock. See [Mock intersections](/testing/mocking-intersections).

--- a/apps/docs/docs/api/configuration.mdx
+++ b/apps/docs/docs/api/configuration.mdx
@@ -24,7 +24,7 @@ useInView({
 });
 ```
 
-`scrollMargin` grows or shrinks the clipping rectangles of nested scroll containers. Reach for it when a scroller inside the root clips the target, not when you want to adjust the viewport.
+`scrollMargin` grows or shrinks the clipping rectangles of scroll containers nested inside the root.
 
 ## Choose where to observe
 

--- a/apps/docs/docs/api/configuration.mdx
+++ b/apps/docs/docs/api/configuration.mdx
@@ -3,9 +3,9 @@ title: Observer options
 description: Decide when observation should trigger, where it should happen, and how long it should run.
 ---
 
-Most components need one of three decisions: **when** an element counts as visible, **where** to observe it, and **what happens after the first notification**. Start there; the full option reference is at the end.
+Most components only need to decide when an element counts as visible, where to observe it, and what happens after the first notification. Those three sections come first. The full option reference is at the end.
 
-Attach `ref` to the target. By default, the browser viewport is the root. An intersection happens when the target crosses that root's bounds; thresholds and margins change when that counts.
+Attach `ref` to the target. The browser viewport is the root by default. An intersection happens when the target crosses that root's bounds, and thresholds and margins move where that line sits.
 
 ## Choose when it counts as visible
 
@@ -24,11 +24,11 @@ useInView({
 });
 ```
 
-`scrollMargin` changes the clipping rectangles of nested scroll containers. Use it when the target is clipped by scrollers inside the root, rather than to adjust the viewport itself.
+`scrollMargin` grows or shrinks the clipping rectangles of nested scroll containers. Reach for it when a scroller inside the root clips the target, not when you want to adjust the viewport.
 
 ## Choose where to observe
 
-For a custom scroll container, start with these rules: the viewport is the default root; pass the ancestor scroll container as `root`; and ensure that root is an ancestor of the observed target. Keep the root in state so the hook receives it after React assigns the element. Omit `root` (or leave it as `null`) to observe relative to the browser viewport, then give a custom root a bounded scrolling area:
+Leave `root` out, or set it to `null`, to observe against the browser viewport. To observe inside a scroll container, pass that container as `root`. It has to be an ancestor of the target, and it needs a bounded scrolling area. Keep it in state so the hook gets the element after React assigns it:
 
 ```tsx
 import { useState } from "react";
@@ -53,17 +53,17 @@ export function ScrollArea() {
 }
 ```
 
-The root must be an ancestor of the target. `scrollMargin` is not a substitute for `rootMargin`: it expands or contracts the clipping rectangles of **nested** scroll containers inside the root. Use it when an inner scroller clips the target, for example `useInView({ root, scrollMargin: "80px 0px" })`. Invalid margin syntax, invalid thresholds, iframes, and custom roots can all change what the browser considers visible.
+`scrollMargin` is not a substitute for `rootMargin`. It only affects nested scroll containers inside the root, as in `useInView({ root, scrollMargin: "80px 0px" })`. Watch out for the things that quietly change what the browser considers visible: invalid margin syntax, thresholds outside `0` to `1`, iframes, and custom roots.
 
 :::note[Verify configuration]
-Test real layout, scrolling, and geometry in [Vitest Browser Mode](/testing/browser-mode). Use a deterministic mock to cross a configured threshold without relying on layout; see [Mock intersections](/testing/mocking-intersections).
+Test real layout, scrolling, and geometry in [Vitest Browser Mode](/testing/browser-mode). To cross a configured threshold without depending on layout, use a deterministic mock. See [Mock intersections](/testing/mocking-intersections).
 :::
 
-## Stop, pause, or choose a callback API
+## Stop or pause observation
 
-Use `triggerOnce` to stop observing after the first accepted `true` transition. Use `skip` to temporarily disable observation while preserving the current state.
+`triggerOnce` stops observing after the first accepted `true` transition. `skip` disables observation and keeps the current state.
 
-Use `onChange` with `useInView` or `<InView>` when you need both React state and a callback. Use [`useOnInView`](/api/core-apis#useoninview) when the callback is the only result you need.
+Use `onChange` with `useInView` or `<InView>` when you want both React state and a callback. Use [`useOnInView`](/api/core-apis#useoninview) when the callback is all you need.
 
 ```tsx
 const { ref, inView } = useInView({
@@ -75,17 +75,17 @@ const { ref, inView } = useInView({
 });
 ```
 
-`onChange` runs alongside the `useInView` or `InView` state update. The callback-only alternative is [`useOnInView`](/api/core-apis#useoninview).
+`onChange` runs alongside the state update.
 
 ## Initial, server, and unsupported-client state
 
-`initialInView` sets the state before an observer reports. `fallbackInView` sets a value only when the client lacks `IntersectionObserver`; a global policy is available through `defaultFallbackInView`.
+`initialInView` sets the state before any observer reports. `fallbackInView` sets a value only when the client has no `IntersectionObserver`, and `defaultFallbackInView` sets that value for the whole application.
 
-Those choices affect server rendering and unsupported browsers, so keep the policy in [SSR and fallbacks](/guides/ssr) rather than scattering it through routine component configuration.
+Both affect server rendering and unsupported browsers. Decide the policy once in [SSR and fallbacks](/guides/ssr) instead of spreading it across individual components.
 
 ## Option reference
 
-Observation options work with all three APIs. `onChange`, `initialInView`, and `fallbackInView` are only available with `useInView` and `<InView>`.
+The observation options work with all three APIs. `onChange`, `initialInView`, and `fallbackInView` only work with `useInView` and `<InView>`.
 
 | Option | Default | Purpose |
 | --- | --- | --- |
@@ -98,15 +98,15 @@ Observation options work with all three APIs. `onChange`, `initialInView`, and `
 | `onChange` | `undefined` | Run `(inView, entry)` after an accepted transition. |
 | `initialInView` | `false` | Set initial state before observer delivery. |
 | `fallbackInView` | `undefined` | Set state when the API is unavailable. |
-| `trackVisibility` | `false` | **Experimental.** Request `entry.isVisible`, beyond geometric intersection, in browsers supporting Observer v2. |
-| `delay` | `undefined` | Minimum delay between v2 visibility notifications. Only use with `trackVisibility`; it must be at least `100`ms. |
+| `trackVisibility` | `false` | Experimental. Ask browsers that support Observer v2 for `entry.isVisible`, which goes beyond geometric intersection. |
+| `delay` | `undefined` | Minimum delay between v2 visibility notifications. Only valid with `trackVisibility`, and must be at least `100`ms. |
 
 ### Experimental v2 options
 
-Most applications only need `inView`: the target intersects the root. Set `trackVisibility: true` when you instead need Observer v2's `entry.isVisible` field, which can account for an intersecting target being visually compromised. Pair it with a `delay` of at least `100` milliseconds:
+Most applications only need `inView`, which means the target intersects the root. Set `trackVisibility: true` when you need Observer v2's `entry.isVisible` field instead, which also accounts for an intersecting target being covered or filtered. Pair it with a `delay` of at least `100` milliseconds:
 
 ```tsx
 useInView({ trackVisibility: true, delay: 100 });
 ```
 
-This is experimental and has narrower browser support than the original API. Read [Observer v2](/guides/intersection-observer-v2) before using `isVisible` for viewability or occlusion decisions.
+Browser support for v2 is narrower than for the original API. Read [Observer v2](/guides/intersection-observer-v2) before you base viewability or occlusion decisions on `isVisible`.

--- a/apps/docs/docs/api/core-apis.mdx
+++ b/apps/docs/docs/api/core-apis.mdx
@@ -3,7 +3,7 @@ title: Core APIs
 description: Choose and use the three React APIs for observing elements.
 ---
 
-`react-intersection-observer`'s primary React surface consists of two hooks and one component. They all use the same observer options, but they express visibility in different ways.
+`react-intersection-observer` exports two hooks and one component. They take the same observer options and differ only in how they hand you the result.
 
 | API | Use it when | What it returns |
 | --- | --- | --- |
@@ -12,14 +12,14 @@ description: Choose and use the three React APIs for observing elements.
 | `<InView>` | Render props or a wrapper component fit the composition. | Render-prop fields, or a generated wrapper for plain children. |
 
 :::note[Initial notification]
-By default, the APIs suppress the observer's first `false` result. `initialInView` sets the starting state and changes how that first notification is handled. Later enter and leave transitions report both `true` and `false`.
+All three APIs suppress the observer's first `false` result. `initialInView` sets the starting state and changes how that first notification is handled. Every enter and leave transition after it reports both `true` and `false`.
 :::
 
-The package also exposes a low-level [`observe`](#low-level-observe) function for code that already owns a DOM element.
+There is also a low-level [`observe`](#low-level-observe) function for code that already owns a DOM element.
 
 ## Common configuration choices
 
-- [Load or reveal once](/api/configuration#stop-pause-or-choose-a-callback-api) with `triggerOnce`.
+- [Load or reveal once](/api/configuration#stop-or-pause-observation) with `triggerOnce`.
 - [Start work before the target reaches the viewport](/api/configuration#choose-when-it-counts-as-visible) with `rootMargin`.
 - [Require a meaningful amount of content to be visible](/api/configuration#choose-when-it-counts-as-visible) with `threshold`.
 - [Observe inside a scrolling container](/api/configuration#choose-where-to-observe) with `root`.
@@ -46,7 +46,7 @@ const { ref, inView, entry } = useInView();
 const [ref, inView, entry] = useInView();
 ```
 
-`entry` is `undefined` until an observer notification has been accepted. It is the latest [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry), so use it for details such as `intersectionRatio`, `boundingClientRect`, or `target` when the UI needs geometry.
+`entry` is `undefined` until the first accepted notification. After that it is the latest [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry), so read `intersectionRatio`, `boundingClientRect`, or `target` from it when the UI needs geometry.
 
 ### `onChange`
 
@@ -60,11 +60,11 @@ const { ref, inView } = useInView({
 });
 ```
 
-Use `useOnInView` when the callback is the primary result and you do not need the state update.
+Use `useOnInView` instead when the callback is the only result you need.
 
 ## `useOnInView`
 
-`useOnInView` returns a ref callback and does not update component state when visibility changes. It is a good fit for analytics, logging, prefetching, or other effects that should not cause a render:
+`useOnInView` returns a ref callback and never updates component state. Use it for analytics, logging, prefetching, and anything else that should not cause a render:
 
 ```tsx
 import { useOnInView } from "react-intersection-observer";
@@ -83,7 +83,7 @@ export function TrackedCard({ id }: { id: string }) {
 }
 ```
 
-The callback receives `(inView, entry)`. `useOnInView` accepts observer options that affect observation, including `root`, `rootMargin`, `scrollMargin`, `threshold`, `triggerOnce`, `skip`, `trackVisibility`, and `delay`. It does not accept `onChange`, `initialInView`, or `fallbackInView`.
+The callback receives `(inView, entry)`. `useOnInView` accepts the options that affect observation: `root`, `rootMargin`, `scrollMargin`, `threshold`, `triggerOnce`, `skip`, `trackVisibility`, and `delay`. It does not accept `onChange`, `initialInView`, or `fallbackInView`.
 
 ## `<InView>`
 
@@ -106,11 +106,11 @@ export function RevealCard() {
 }
 ```
 
-Render-prop fields are `{ ref, inView, entry }`. The `ref` must be attached to the element you want to observe.
+The render prop receives `{ ref, inView, entry }`. Attach the `ref` to the element you want to observe.
 
 ### Plain children
 
-Plain children are always rendered. In this form `<InView>` creates a wrapper element, forwards additional HTML props to that wrapper, and observes it:
+Plain children always render. In this form `<InView>` creates a wrapper element, forwards any extra HTML props to it, and observes it:
 
 ```tsx
 <InView as="section" className="article" onChange={handleChange}>
@@ -118,11 +118,11 @@ Plain children are always rendered. In this form `<InView>` creates a wrapper el
 </InView>
 ```
 
-Use `as` to keep the generated wrapper semantic. Plain-child mode does not support ref forwarding; use render props or `useInView` when you need direct control of the observed element or a custom component ref.
+Use `as` to keep the generated wrapper semantic. This form does not forward refs. Use render props or `useInView` when you need direct control of the observed element, or a ref on a custom component.
 
 ## Low-level `observe`
 
-The three APIs above are the React surface. When you already own a DOM element outside React rendering, use the low-level `observe` function and always keep its cleanup function:
+When you already own a DOM element outside React rendering, use the low-level `observe` function. Keep the cleanup function it returns:
 
 ```ts
 import { observe } from "react-intersection-observer";
@@ -143,7 +143,7 @@ stop();
 
 - `triggerOnce` stops observing after the first accepted `true` transition.
 - `skip` disables observation while preserving the current state.
-- When an observed node is removed and later replaced, the hook resets to `initialInView` unless `triggerOnce` or `skip` prevents that reset.
-- The latest `entry` may be `undefined` before the first accepted notification or after an observed node is reset.
+- When an observed node is removed and later replaced, the hook resets to `initialInView`, unless `triggerOnce` or `skip` prevents the reset.
+- `entry` is `undefined` before the first accepted notification, and again after an observed node resets.
 
 See [Configuration](/api/configuration) for every option and [Testing](/testing) for deterministic observer transitions.

--- a/apps/docs/docs/guides/intersection-observer-v2.mdx
+++ b/apps/docs/docs/guides/intersection-observer-v2.mdx
@@ -1,12 +1,12 @@
 ---
 title: Observer v2
-description: Use trackVisibility only when intersection alone is insufficient and you accept narrower browser support.
+description: Use trackVisibility only when intersection alone is not enough and you accept narrower browser support.
 sidebar:
   label: Observer v2
   badge: Experimental
 ---
 
-Most applications should use the standard `inView` signal. Intersection Observer v2 adds `trackVisibility` and `entry.isVisible` for specialised viewability cases where an intersecting element may be covered or visually compromised.
+Most applications should stick with the standard `inView` signal. Intersection Observer v2 adds `trackVisibility` and `entry.isVisible` for viewability cases where an intersecting element may be covered by something else or hidden behind a filter.
 
 ## Enable visibility tracking
 
@@ -38,16 +38,16 @@ export function Viewability({ onSeen }: { onSeen: () => void }) {
 }
 ```
 
-`isVisible` is not yet part of TypeScript's standard `IntersectionObserverEntry` declaration, so add the augmentation once in application types before reading it. The option is available on all three public APIs. With `useOnInView`, inspect `entry.isVisible` inside the callback; with `<InView>`, inspect it from the render-prop `entry` or `onChange` callback.
+`isVisible` is not in TypeScript's `IntersectionObserverEntry` declaration yet, so add the augmentation once in your application types before reading it. The option works with all three APIs. With `useOnInView`, read `entry.isVisible` inside the callback. With `<InView>`, read it from the render-prop `entry` or from `onChange`.
 
 ## Support and fallback behavior
 
-Support for v2 is narrower than support for the original Intersection Observer API. When the browser exposes Intersection Observer but does not provide `isVisible`, this package falls back to v1 behavior and sets `entry.isVisible` to the calculated intersection state. Treat that value as an approximation in unsupported browsers.
+Fewer browsers support v2 than the original API. When a browser has Intersection Observer but no `isVisible`, this package falls back to v1 and sets `entry.isVisible` to the calculated intersection state. Treat that value as an approximation there.
 
-If the entire `IntersectionObserver` API is unavailable, use `fallbackInView` or `defaultFallbackInView` as described in [Configuration](/api/configuration). These are separate concerns: v2 fallback covers a missing visibility field, while `fallbackInView` covers a missing observer API.
+Missing `isVisible` and a missing observer are separate problems. If the whole `IntersectionObserver` API is unavailable, use `fallbackInView` or `defaultFallbackInView` as described in [Configuration](/api/configuration).
 
 ## Test it deliberately
 
-Use a real browser when verifying geometry, clipping, or actual occlusion. The package mock can exercise the v1 fallback branch, but it cannot simulate an intersecting element being covered. For deterministic callback and threshold tests, assert the application behavior you need rather than actual occlusion.
+Verify geometry, clipping, and real occlusion in a real browser. The package mock can drive the v1 fallback branch and your callback, but it cannot cover one element with another, so it can never prove occlusion. In deterministic tests, assert the application behavior you need instead.
 
-Keep the minimum delay explicit in shared configuration so a future browser or package update does not silently make the observer invalid. The package mock can exercise your callback branch, but it cannot prove real occlusion.
+Keep the minimum `delay` in shared configuration so a future browser or package update cannot quietly make the observer invalid.

--- a/apps/docs/docs/guides/intersection-observer-v2.mdx
+++ b/apps/docs/docs/guides/intersection-observer-v2.mdx
@@ -46,7 +46,7 @@ Fewer browsers support v2 than the original API. When a browser has Intersection
 
 Missing `isVisible` and a missing observer are separate problems. If the whole `IntersectionObserver` API is unavailable, use `fallbackInView` or `defaultFallbackInView` as described in [Configuration](/api/configuration).
 
-## Test it deliberately
+## Test it in a real browser
 
 Verify geometry, clipping, and real occlusion in a real browser. The package mock can drive the v1 fallback branch and your callback, but it cannot cover one element with another, so it can never prove occlusion. In deterministic tests, assert the application behavior you need instead.
 

--- a/apps/docs/docs/guides/recipes.mdx
+++ b/apps/docs/docs/guides/recipes.mdx
@@ -136,7 +136,7 @@ An intersection does not prove anyone actually looked at the content. Add a mini
 Observe a sentinel at the end of the list, guard requests while one is in flight, and keep a real button for keyboard and assistive-technology users:
 
 ```tsx
-import { useState, type Key, type ReactNode } from "react";
+import { useState, useTransition, type Key, type ReactNode } from "react";
 import { useInView } from "react-intersection-observer";
 
 type Page<T> = { items: T[]; hasNextPage: boolean };
@@ -152,25 +152,27 @@ export function InfiniteList<T>({
 }) {
   const [items, setItems] = useState<T[]>([]);
   const [hasNextPage, setHasNextPage] = useState(true);
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+  const [failed, setFailed] = useState(false);
+  const [isPending, startTransition] = useTransition();
 
   function loadMore() {
-    if (status === "loading" || !hasNextPage) return;
+    if (isPending || !hasNextPage) return;
 
-    setStatus("loading");
-    loadPage(items.length).then(
-      (page) => {
+    setFailed(false);
+    startTransition(async () => {
+      try {
+        const page = await loadPage(items.length);
         setItems((current) => [...current, ...page.items]);
         setHasNextPage(page.hasNextPage);
-        setStatus("idle");
-      },
-      () => setStatus("error"),
-    );
+      } catch {
+        setFailed(true);
+      }
+    });
   }
 
   const { ref } = useInView({
     rootMargin: "400px 0px",
-    skip: status !== "idle" || !hasNextPage,
+    skip: isPending || failed || !hasNextPage,
     onChange: (inView) => {
       if (inView) loadMore();
     },
@@ -185,15 +187,15 @@ export function InfiniteList<T>({
       </ul>
 
       <p aria-live="polite">
-        {status === "loading" ? "Loading more items…" : null}
-        {status === "error" ? "Could not load more items." : null}
+        {isPending ? "Loading more items…" : null}
+        {failed ? "Could not load more items." : null}
       </p>
 
       {hasNextPage ? (
         <>
           <div ref={ref} aria-hidden="true" />
-          <button disabled={status === "loading"} onClick={loadMore}>
-            {status === "error" ? "Try again" : "Load more"}
+          <button disabled={isPending} onClick={loadMore}>
+            {failed ? "Try again" : "Load more"}
           </button>
         </>
       ) : null}
@@ -204,11 +206,15 @@ export function InfiniteList<T>({
 
 <ObserverDemo recipe="infinite-list" />
 
-There is no effect here, and that is the point. An empty list puts the sentinel inside the viewport, so the observer asks for the first page through the same path as every page after it. An effect for the first page would duplicate the fetch, the error handling, and the loading flag, then race the observer for the same request.
+:::note[React 19]
+Passing an async function to `startTransition` needs React 19. On React 18, only the updates you schedule before the first `await` are part of the transition, so `isPending` clears too early. Track a `"idle" | "loading" | "error"` status yourself there.
+:::
 
-One `status` beats separate `loading` and `error` booleans: the component cannot be loading and failed at the same time, and the retry button reads its own label from it.
+There is no effect here, and that is the point. An empty list puts the sentinel inside the viewport, so the observer asks for the first page through the same path as every page after it. An effect for the first page would duplicate the fetch, the error handling, and the pending flag, then race the observer for the same request.
 
-`loadMore` is not `async`. Nothing awaits it, so returning a promise would only invite a caller to try. It starts the request and reports the outcome through state, which is what both the observer and the button want.
+`useTransition` owns that pending flag. React raises `isPending` when `startTransition` runs and lowers it when the awaited work settles, so there is no `setLoading(true)` to pair with a `setLoading(false)` on every exit path. `startTransition` also awaits the async function you hand it, so nothing floats. Marking the append as a transition is worth it on its own: re-rendering a list that has grown to hundreds of rows no longer blocks a click or a keystroke.
+
+A hand-rolled loading boolean is also less reliable here. When `loadPage` resolves from a warm cache without ever yielding, React can batch the update that sets the flag together with the one that clears it. The observer then never sees `skip` change, and the list stops after one page. `isPending` renders either way.
 
 `skip` does two jobs. It keeps a second request from starting while one is in flight, and because the hook drops and recreates the observer when `skip` flips back, it re-arms the sentinel. A page too short to push the sentinel out of view keeps loading until the viewport fills.
 

--- a/apps/docs/docs/guides/recipes.mdx
+++ b/apps/docs/docs/guides/recipes.mdx
@@ -207,19 +207,13 @@ export function InfiniteList<T>({
 <ObserverDemo recipe="infinite-list" />
 
 :::note[React 19]
-Passing an async function to `startTransition` needs React 19. On React 18, only the updates you schedule before the first `await` are part of the transition, so `isPending` clears too early. Track a `"idle" | "loading" | "error"` status yourself there.
+Passing an async function to `startTransition` needs React 19. On React 18 `isPending` clears at the first `await`, so track a loading status yourself there.
 :::
 
-There is no effect here. An empty list puts the sentinel in the viewport, so the observer requests the first page the same way it requests every page after it. Add an effect for that first page and you get a second copy of the fetch and the error handling, racing the observer for the same request.
+The sentinel starts inside the viewport, so the observer loads the first page too.
 
-`useTransition` tracks the pending state for you. React sets `isPending` when `startTransition` runs and clears it once the awaited work settles, so there is no `setLoading(false)` to repeat on every exit path. `startTransition` also awaits the async function you give it, so there is no unawaited promise. The append becomes a transition as well, which lets a list of hundreds of rows re-render without blocking a click.
+`skip` stops a second request while one is in flight. It also re-arms the sentinel, because the hook drops and recreates the observer each time `skip` flips back, so a page too short to fill the viewport keeps loading.
 
-A hand-rolled loading boolean breaks in one specific case. When `loadPage` resolves from a warm cache, React can batch the update that sets the flag with the one that clears it. `skip` never changes, the observer never starts again, and the list stops after one page. `isPending` always produces a render.
+`rootMargin` starts the request before the sentinel is visible. Tune `400px` to your network and item size, and send whatever page key your API expects instead of `items.length`.
 
-The transition has no error channel, so the `try`/`catch` stays. Drop it and the throw reaches the nearest error boundary, which swaps the list for a fallback and takes every page already loaded with it. Catching here keeps the rows on screen and turns the button into a retry.
-
-`skip` does two jobs. It stops a second request while one is in flight. It also gets the sentinel watching again, because the hook drops the observer and creates a new one each time `skip` flips back. So a page too short to push the sentinel out of view keeps loading until the viewport fills.
-
-`rootMargin` starts the request before the sentinel reaches the viewport. Tune the `400px` value to your network and item size. This example sends `items.length` as the next page's `skip`; use whatever pagination your API expects.
-
-Keep the button. It is the retry after a failure, and it is the only route for keyboard and assistive-technology users. Scrolling should never be the only way to fetch content.
+Keep the button. Scrolling should never be the only way to load more.

--- a/apps/docs/docs/guides/recipes.mdx
+++ b/apps/docs/docs/guides/recipes.mdx
@@ -210,14 +210,16 @@ export function InfiniteList<T>({
 Passing an async function to `startTransition` needs React 19. On React 18, only the updates you schedule before the first `await` are part of the transition, so `isPending` clears too early. Track a `"idle" | "loading" | "error"` status yourself there.
 :::
 
-There is no effect here, and that is the point. An empty list puts the sentinel inside the viewport, so the observer asks for the first page through the same path as every page after it. An effect for the first page would duplicate the fetch, the error handling, and the pending flag, then race the observer for the same request.
+There is no effect here. An empty list puts the sentinel in the viewport, so the observer requests the first page the same way it requests every page after it. Add an effect for that first page and you get a second copy of the fetch and the error handling, racing the observer for the same request.
 
-`useTransition` owns that pending flag. React raises `isPending` when `startTransition` runs and lowers it when the awaited work settles, so there is no `setLoading(true)` to pair with a `setLoading(false)` on every exit path. `startTransition` also awaits the async function you hand it, so nothing floats. Marking the append as a transition is worth it on its own: re-rendering a list that has grown to hundreds of rows no longer blocks a click or a keystroke.
+`useTransition` tracks the pending state for you. React sets `isPending` when `startTransition` runs and clears it once the awaited work settles, so there is no `setLoading(false)` to repeat on every exit path. `startTransition` also awaits the async function you give it, so there is no unawaited promise. The append becomes a transition as well, which lets a list of hundreds of rows re-render without blocking a click.
 
-A hand-rolled loading boolean is also less reliable here. When `loadPage` resolves from a warm cache without ever yielding, React can batch the update that sets the flag together with the one that clears it. The observer then never sees `skip` change, and the list stops after one page. `isPending` renders either way.
+A hand-rolled loading boolean breaks in one specific case. When `loadPage` resolves from a warm cache, React can batch the update that sets the flag with the one that clears it. `skip` never changes, the observer never starts again, and the list stops after one page. `isPending` always produces a render.
 
-`skip` does two jobs. It keeps a second request from starting while one is in flight, and because the hook drops and recreates the observer when `skip` flips back, it re-arms the sentinel. A page too short to push the sentinel out of view keeps loading until the viewport fills.
+The transition has no error channel, so the `try`/`catch` stays. Drop it and the throw reaches the nearest error boundary, which swaps the list for a fallback and takes every page already loaded with it. Catching here keeps the rows on screen and turns the button into a retry.
+
+`skip` does two jobs. It stops a second request while one is in flight. It also gets the sentinel watching again, because the hook drops the observer and creates a new one each time `skip` flips back. So a page too short to push the sentinel out of view keeps loading until the viewport fills.
 
 `rootMargin` starts the request before the sentinel reaches the viewport. Tune the `400px` value to your network and item size. This example sends `items.length` as the next page's `skip`; use whatever pagination your API expects.
 
-Keep the button. It retries after an error, it is the only route for keyboard and assistive-technology users, and it is the guaranteed way forward if the observer never fires again. Scrolling should never be the only way to fetch content.
+Keep the button. It is the retry after a failure, and it is the only route for keyboard and assistive-technology users. Scrolling should never be the only way to fetch content.

--- a/apps/docs/docs/guides/recipes.mdx
+++ b/apps/docs/docs/guides/recipes.mdx
@@ -3,15 +3,15 @@ title: Recipes
 description: Complete visibility-aware React patterns built with react-intersection-observer.
 ---
 
-Each recipe starts with the problem it solves, shows a complete component, and calls out the boundary that is easiest to miss. For the API details behind the examples, see [Core APIs](/api/core-apis) and [Configuration](/api/configuration).
+Each recipe states the problem, shows a complete component, and calls out the part that is easiest to get wrong. For the API details behind the examples, see [Core APIs](/api/core-apis) and [Configuration](/api/configuration).
 
 ## Lazy image loading
 
 :::tip[Prefer native lazy loading]
-Add the `loading="lazy"` attribute to ordinary image elements. It lets the browser decide when to defer image loading without any observer code.
+Add `loading="lazy"` to ordinary image elements and the browser defers loading for you, with no observer code.
 :::
 
-Use the observer when you need an explicit preload margin, a custom placeholder, or a component-level loading transition.
+Reach for the observer when you need a specific preload margin, a custom placeholder, or a loading transition on the component.
 
 ```tsx
 import { useInView } from "react-intersection-observer";
@@ -43,7 +43,7 @@ export function LazyImage({ src, alt, width, height }: LazyImageProps) {
 
 <ObserverDemo recipe="lazy-image" />
 
-Reserve the image's space with dimensions or an aspect ratio. Otherwise the image can shift the page after it loads, and the observer may repeatedly encounter a moving target.
+Reserve the image's space with dimensions or an aspect ratio. Without it the image shifts the page when it loads, and the observer keeps chasing a moving target.
 
 ## Scroll-triggered animation
 
@@ -99,7 +99,7 @@ export function Reveal({ children }: { children: React.ReactNode }) {
 
 <ObserverDemo recipe="reveal" />
 
-The baseline remains visible until the browser can enhance it, and `fallbackInView: true` keeps it visible when observation is unavailable. Do not make the animation the only way to discover important content; reduced-motion users see it immediately.
+The content stays visible until the observer takes over, and `fallbackInView: true` keeps it visible when observation never arrives. Never make the animation the only way to find important content. Reduced-motion users see it right away.
 
 ## Track an impression
 
@@ -127,11 +127,13 @@ export function Impression({ id, record }: ImpressionProps) {
 
 <ObserverDemo recipe="impression" />
 
-The package ignores the initial `false` notification, so this callback records the first accepted enter transition. Keep the identifier stable and decide whether `triggerOnce` matches your analytics definition of an impression. An intersection does not prove that content was meaningfully viewed: add a minimum-duration rule when your definition requires time in view, and evaluate [Observer v2](/guides/intersection-observer-v2) when covered or visually compromised content matters.
+The package ignores the initial `false` notification, so this callback records the first accepted enter transition. Keep the identifier stable, and check that `triggerOnce` matches what your analytics counts as an impression.
+
+An intersection does not prove anyone actually looked at the content. Add a minimum-duration rule if your definition requires time in view, and look at [Observer v2](/guides/intersection-observer-v2) if covered or filtered content matters to you.
 
 ## Infinite scrolling
 
-Observe a sentinel at the end of a list, guard requests while loading, and keep an explicit fallback action for keyboard and assistive-technology users:
+Observe a sentinel at the end of the list, guard requests while loading, and keep a real button for keyboard and assistive-technology users:
 
 ```tsx
 import { useCallback, useEffect, useState, type Key, type ReactNode } from "react";
@@ -222,4 +224,6 @@ export function InfiniteList<T>({
 
 <ObserverDemo recipe="infinite-list" />
 
-Start with `loading: true` so the sentinel cannot race the first request. After that, the `skip` guard prevents duplicate requests. `rootMargin` can begin loading before the sentinel reaches the viewport; tune its `400px` value to the network and item size. The `items.length` value is the next page's `skip`; use the pagination contract your API expects. Always keep a manual “Load more” path and retry boundary rather than making scrolling the only way to fetch content.
+Start with `loading: true` so the sentinel cannot race the first request. After that, the `skip` guard blocks duplicate requests. `rootMargin` starts the load before the sentinel reaches the viewport, so tune the `400px` value to your network and item size. This example sends `items.length` as the next page's `skip`; use whatever pagination your API expects.
+
+Keep the manual "Load more" button and the retry path. Scrolling should never be the only way to fetch content.

--- a/apps/docs/docs/guides/recipes.mdx
+++ b/apps/docs/docs/guides/recipes.mdx
@@ -133,10 +133,10 @@ An intersection does not prove anyone actually looked at the content. Add a mini
 
 ## Infinite scrolling
 
-Observe a sentinel at the end of the list, guard requests while loading, and keep a real button for keyboard and assistive-technology users:
+Observe a sentinel at the end of the list, guard requests while one is in flight, and keep a real button for keyboard and assistive-technology users:
 
 ```tsx
-import { useCallback, useEffect, useState, type Key, type ReactNode } from "react";
+import { useState, type Key, type ReactNode } from "react";
 import { useInView } from "react-intersection-observer";
 
 type Page<T> = { items: T[]; hasNextPage: boolean };
@@ -152,51 +152,25 @@ export function InfiniteList<T>({
 }) {
   const [items, setItems] = useState<T[]>([]);
   const [hasNextPage, setHasNextPage] = useState(true);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
 
-  const loadMore = useCallback(async () => {
-    if (loading || !hasNextPage) return;
+  async function loadMore() {
+    if (status === "loading" || !hasNextPage) return;
 
-    setLoading(true);
-    setError(null);
+    setStatus("loading");
     try {
       const page = await loadPage(items.length);
       setItems((current) => [...current, ...page.items]);
       setHasNextPage(page.hasNextPage);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause : new Error("Unable to load"));
-    } finally {
-      setLoading(false);
+      setStatus("idle");
+    } catch {
+      setStatus("error");
     }
-  }, [hasNextPage, items.length, loadPage, loading]);
-
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    void loadPage(0)
-      .then((page) => {
-        if (cancelled) return;
-        setItems(page.items);
-        setHasNextPage(page.hasNextPage);
-      })
-      .catch((cause) => {
-        if (!cancelled) {
-          setError(cause instanceof Error ? cause : new Error("Unable to load"));
-        }
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [loadPage]);
+  }
 
   const { ref } = useInView({
     rootMargin: "400px 0px",
-    skip: loading || !hasNextPage || error !== null,
+    skip: status !== "idle" || !hasNextPage,
     onChange: (inView) => {
       if (inView) void loadMore();
     },
@@ -204,16 +178,22 @@ export function InfiniteList<T>({
 
   return (
     <>
-      <ul>{items.map((item) => <li key={getKey(item)}>{renderItem(item)}</li>)}</ul>
+      <ul>
+        {items.map((item) => (
+          <li key={getKey(item)}>{renderItem(item)}</li>
+        ))}
+      </ul>
+
       <p aria-live="polite">
-        {loading ? "Loading more items…" : error ? "Could not load more items." : ""}
+        {status === "loading" ? "Loading more items…" : null}
+        {status === "error" ? "Could not load more items." : null}
       </p>
-      {error ? <button onClick={() => void loadMore()}>Try again</button> : null}
+
       {hasNextPage ? (
         <>
           <div ref={ref} aria-hidden="true" />
-          <button disabled={loading} onClick={() => void loadMore()}>
-            {loading ? "Loading…" : "Load more"}
+          <button disabled={status === "loading"} onClick={() => void loadMore()}>
+            {status === "error" ? "Try again" : "Load more"}
           </button>
         </>
       ) : null}
@@ -224,6 +204,12 @@ export function InfiniteList<T>({
 
 <ObserverDemo recipe="infinite-list" />
 
-Start with `loading: true` so the sentinel cannot race the first request. After that, the `skip` guard blocks duplicate requests. `rootMargin` starts the load before the sentinel reaches the viewport, so tune the `400px` value to your network and item size. This example sends `items.length` as the next page's `skip`; use whatever pagination your API expects.
+There is no effect here, and that is the point. An empty list puts the sentinel inside the viewport, so the observer asks for the first page through the same path as every page after it. An effect for the first page would duplicate the fetch, the error handling, and the loading flag, then race the observer for the same request.
 
-Keep the manual "Load more" button and the retry path. Scrolling should never be the only way to fetch content.
+One `status` beats separate `loading` and `error` booleans: the component cannot be loading and failed at the same time, and the retry button reads its own label from it.
+
+`skip` does two jobs. It keeps a second request from starting while one is in flight, and because the hook drops and recreates the observer when `skip` flips back, it re-arms the sentinel. A page too short to push the sentinel out of view keeps loading until the viewport fills.
+
+`rootMargin` starts the request before the sentinel reaches the viewport. Tune the `400px` value to your network and item size. This example sends `items.length` as the next page's `skip`; use whatever pagination your API expects.
+
+Keep the button. It retries after an error, it is the only route for keyboard and assistive-technology users, and it is the guaranteed way forward if the observer never fires again. Scrolling should never be the only way to fetch content.

--- a/apps/docs/docs/guides/recipes.mdx
+++ b/apps/docs/docs/guides/recipes.mdx
@@ -133,7 +133,7 @@ An intersection does not prove anyone actually looked at the content. Add a mini
 
 ## Infinite scrolling
 
-Observe a sentinel at the end of the list, guard requests while one is in flight, and keep a real button for keyboard and assistive-technology users:
+Observe a sentinel at the end of the list, guard requests while one is in flight, and add a real button for keyboard and assistive-technology users:
 
 ```tsx
 import { useState, useTransition, type Key, type ReactNode } from "react";
@@ -216,4 +216,4 @@ The sentinel starts inside the viewport, so the observer loads the first page to
 
 `rootMargin` starts the request before the sentinel is visible. Tune `400px` to your network and item size, and send whatever page key your API expects instead of `items.length`.
 
-Keep the button. Scrolling should never be the only way to load more.
+Scrolling should never be the only way to load more.

--- a/apps/docs/docs/guides/recipes.mdx
+++ b/apps/docs/docs/guides/recipes.mdx
@@ -154,25 +154,25 @@ export function InfiniteList<T>({
   const [hasNextPage, setHasNextPage] = useState(true);
   const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
 
-  async function loadMore() {
+  function loadMore() {
     if (status === "loading" || !hasNextPage) return;
 
     setStatus("loading");
-    try {
-      const page = await loadPage(items.length);
-      setItems((current) => [...current, ...page.items]);
-      setHasNextPage(page.hasNextPage);
-      setStatus("idle");
-    } catch {
-      setStatus("error");
-    }
+    loadPage(items.length).then(
+      (page) => {
+        setItems((current) => [...current, ...page.items]);
+        setHasNextPage(page.hasNextPage);
+        setStatus("idle");
+      },
+      () => setStatus("error"),
+    );
   }
 
   const { ref } = useInView({
     rootMargin: "400px 0px",
     skip: status !== "idle" || !hasNextPage,
     onChange: (inView) => {
-      if (inView) void loadMore();
+      if (inView) loadMore();
     },
   });
 
@@ -192,7 +192,7 @@ export function InfiniteList<T>({
       {hasNextPage ? (
         <>
           <div ref={ref} aria-hidden="true" />
-          <button disabled={status === "loading"} onClick={() => void loadMore()}>
+          <button disabled={status === "loading"} onClick={loadMore}>
             {status === "error" ? "Try again" : "Load more"}
           </button>
         </>
@@ -207,6 +207,8 @@ export function InfiniteList<T>({
 There is no effect here, and that is the point. An empty list puts the sentinel inside the viewport, so the observer asks for the first page through the same path as every page after it. An effect for the first page would duplicate the fetch, the error handling, and the loading flag, then race the observer for the same request.
 
 One `status` beats separate `loading` and `error` booleans: the component cannot be loading and failed at the same time, and the retry button reads its own label from it.
+
+`loadMore` is not `async`. Nothing awaits it, so returning a promise would only invite a caller to try. It starts the request and reports the outcome through state, which is what both the observer and the button want.
 
 `skip` does two jobs. It keeps a second request from starting while one is in flight, and because the hook drops and recreates the observer when `skip` flips back, it re-arms the sentinel. A page too short to push the sentinel out of view keeps loading until the viewport fills.
 

--- a/apps/docs/docs/guides/ssr.mdx
+++ b/apps/docs/docs/guides/ssr.mdx
@@ -3,11 +3,11 @@ title: SSR and fallbacks
 description: Separate server-rendered state, unsupported browsers, hydration, and application fallback policy.
 ---
 
-Intersection Observer is only available in a browser. Decide the server-rendered state, what may change after hydration, and how unsupported clients should behave together. `initialInView` controls the pre-observer render; it does not create an observer or guarantee that the target is visible. Hydration attaches the observer after the browser takes over, and a client without `IntersectionObserver` throws unless a fallback is configured. Use `fallbackInView` for one instance and `defaultFallbackInView` as an application-wide policy.
+Intersection Observer only exists in a browser, so decide three things together: what the server renders, what may change after hydration, and how a client without the API should behave. `initialInView` covers the first, `fallbackInView` covers one component in the third, and `defaultFallbackInView` sets that policy for the whole application.
 
 ## Choose the initial policy
 
-Use `initialInView` when you know how a component should render before the first observer notification:
+Use `initialInView` when you already know how a component should render before the first observer notification:
 
 ```tsx
 const { ref, inView } = useInView({
@@ -15,11 +15,11 @@ const { ref, inView } = useInView({
 });
 ```
 
-This is useful when above-the-fold content should begin in its visible state. It only controls the pre-observer render; it does not create an observer or guarantee that the target is visible.
+This helps when above-the-fold content should start out visible. It only controls the render before the observer reports. It does not create an observer, and it does not guarantee the target is visible.
 
 ## Fallback for unsupported clients
 
-If the observer API is unavailable, the default behavior is to throw. Set a local fallback when the policy belongs to one component:
+If the observer API is missing, the default behavior is to throw. Set a local fallback when the decision belongs to one component:
 
 ```tsx
 const { ref, inView } = useInView({
@@ -35,14 +35,10 @@ import { defaultFallbackInView } from "react-intersection-observer";
 defaultFallbackInView(false);
 ```
 
-Use `true` when content should be treated as visible even without observation. Use `false` when visibility should remain conservative and lazy work must not start automatically. Whichever value you choose, make sure the resulting behavior is safe for every observer in the application; a global fallback affects all instances that do not provide their own value.
+Pick `true` when content should count as visible even without observation. Pick `false` when lazy work must not start on its own. Either way, check that the result is safe for every observer in the application, because a global fallback applies to every instance that does not set its own value.
 
-fallbackInView is the local fallback for one hook or component. defaultFallbackInView is the global policy for every instance that does not provide its own fallback.
+## Hydration
 
-## Hydration considerations
+Hydration attaches the observer once the browser takes over, so nothing is observed during the server render. `entry` is `undefined` until an accepted notification arrives, and reading geometry from it on the server will fail.
 
-Hydration attaches the observer after the browser takes over. `initialInView` only controls the pre-observer render: it does not create an observer or guarantee the target is visible. A client without IntersectionObserver throws unless a fallback is configured.
-
-Avoid using an observer fallback as a substitute for a loading strategy. If the server renders hidden content and the client immediately renders visible content, reserve layout space and keep the change accessible. For images, provide dimensions and consider native `loading="lazy"`; for important content, ensure it remains available when observation is unavailable.
-
-`entry` is `undefined` until an accepted observer notification exists. Do not read geometry from it during the server render.
+A fallback is not a loading strategy. If the server renders hidden content and the client immediately renders it visible, reserve the layout space and keep the change accessible. Give images dimensions and consider native `loading="lazy"`. For content that matters, make sure it is still reachable when observation is unavailable.

--- a/apps/docs/docs/guides/ssr.mdx
+++ b/apps/docs/docs/guides/ssr.mdx
@@ -41,4 +41,4 @@ Pick `true` when content should count as visible even without observation. Pick 
 
 Hydration attaches the observer once the browser takes over, so nothing is observed during the server render. `entry` is `undefined` until an accepted notification arrives, and reading geometry from it on the server will fail.
 
-A fallback is not a loading strategy. If the server renders hidden content and the client immediately renders it visible, reserve the layout space and keep the change accessible. Give images dimensions and consider native `loading="lazy"`. For content that matters, make sure it is still reachable when observation is unavailable.
+If the server renders hidden content and the client immediately renders it visible, reserve the layout space and keep the change accessible. Give images dimensions and consider native `loading="lazy"`. For content that matters, make sure it is still reachable when observation is unavailable.

--- a/apps/docs/docs/overview.mdx
+++ b/apps/docs/docs/overview.mdx
@@ -13,7 +13,7 @@ sidebar:
 
 Use it to [lazy-load content](/guides/recipes#lazy-image-loading), trigger [scroll-based animations](/guides/recipes#scroll-triggered-animation), [track impressions](/guides/recipes#track-an-impression), prefetch data, highlight visible sections, and [load more results](/guides/recipes#infinite-scrolling).
 
-## Start simple
+## Install
 
 ```package-install
 react-intersection-observer
@@ -29,9 +29,9 @@ export function Section() {
 }
 ```
 
-Attach `ref` to an element and use `inView` in the render. By default, the browser viewport is the root and any intersection changes the state. Configure a threshold, margin, or custom root only when that default is not enough.
+Attach `ref` to an element and use `inView` in the render. The browser viewport is the root by default, and any intersection flips the state. Set a threshold, margin, or custom root when that default is not enough.
 
-When you need geometry, `entry` is the latest observer result; it is `undefined` until the browser accepts a notification.
+`entry` is the latest observer result, so read geometry from it. It stays `undefined` until the browser delivers the first accepted notification.
 
 ## Choose an API
 
@@ -41,24 +41,22 @@ When you need geometry, `entry` is the latest observer result; it is `undefined`
 | Run an impression, prefetch, or analytics callback | [`useOnInView`](/api/core-apis#useoninview) | Calls your callback without a hook-owned state update. |
 | Keep observation close to render props or a wrapper | [`<InView>`](/api/core-apis#inview) | Provides render props and supports plain children. |
 
-## See it work
+## Try it
 
-The basic hook above uses the browser viewport. This demo adds a custom scroll root and a threshold so you can see how options change the same `inView` state.
+The hook above uses the browser viewport. This demo adds a custom scroll root and a threshold, so you can see how options change the same `inView` state.
 
 <ObserverDemo />
 
-## Built for production React
+## What you get
 
+- **Shared observer instances.** Targets that use the same options share one `IntersectionObserver`, so observing hundreds of elements is cheap.
+- **Types in the package.** Hooks, components, options, and entries are typed. There is no `@types` package to install.
+- **Two test layers.** `react-intersection-observer/test-utils` drives deterministic transitions, and [Browser Mode](/testing/browser-mode) runs the browser's own observer.
+- **Separate entry points.** Import only `useInView` and the rest is tree shaken away, around 1.15kB gzipped.
 
-- **Native and efficient.** Familiar browser options and shared observer instances keep many observed elements inexpensive.
-- **Typed and composable.** Hooks, components, options, and observer entries are typed without another package.
-- **Testable at the right layer.** Use deterministic utilities for transitions and [Browser Mode](/testing/browser-mode) for real browser behavior.
-- **Focused exports.** Tree shaking keeps the client footprint limited to the APIs you import.
+## Where to go next
 
-## Common next steps
-
-- [**Core APIs**](/api/core-apis) — learn the full contracts and return values.
-- [**Observer options**](/api/configuration) — tune thresholds, margins, and scroll containers.
-- [**Recipes**](/guides/recipes) — build lazy loading, reveals, impressions, and infinite lists.
-
-For verification, see [Testing](/testing); for server-rendered apps, see [SSR and fallbacks](/guides/ssr).
+- [Core APIs](/api/core-apis) covers the full contracts and return values.
+- [Observer options](/api/configuration) covers thresholds, margins, and scroll containers.
+- [Recipes](/guides/recipes) builds lazy loading, reveals, impressions, and infinite lists.
+- [Testing](/testing) covers verification, and [SSR and fallbacks](/guides/ssr) covers server rendering.

--- a/apps/docs/docs/testing/browser-mode.mdx
+++ b/apps/docs/docs/testing/browser-mode.mdx
@@ -3,13 +3,13 @@ title: Browser Mode
 description: Use Vitest Browser Mode to test real scrolling, layout, focus, and native Intersection Observer behavior.
 ---
 
-Vitest Browser Mode runs your component test in a real browser—not a simulated DOM. That gives the test real viewport geometry, CSS layout, scrolling, focus, and the browser's own `IntersectionObserver` implementation.
+Vitest Browser Mode runs your component test in a real browser instead of a simulated DOM. The test gets real viewport geometry, CSS layout, scrolling, focus, and the browser's own `IntersectionObserver`.
 
-Use it when the browser itself is part of the behavior you need to prove: an element enters a scroll container, a `rootMargin` starts work early, a layout change moves a target, or the native observer delivers an update. Browser Mode is the preferred integration test layer for those cases.
+Use it when the browser is part of what you need to prove. An element entering a scroll container, a `rootMargin` starting work early, a layout change moving a target, the native observer delivering an update: none of those are provable against a fake DOM.
 
 ## Keep Browser Mode separate from mocked DOM tests
 
-Run Browser Mode tests in a Chromium browser project. Keep them separate from `happy-dom` or `jsdom` tests that load `react-intersection-observer/test-utils`; the native browser observer must remain available to prove scrolling, layout, and observer delivery.
+Run Browser Mode tests in a Chromium browser project, separate from the `happy-dom` or `jsdom` tests that load `react-intersection-observer/test-utils`. The native observer has to stay in place, or the test proves nothing about scrolling, layout, or observer delivery.
 
 ## Install and configure Browser Mode
 
@@ -20,7 +20,7 @@ pnpm add -D vitest vitest-browser-react @vitest/browser-playwright playwright
 pnpm exec playwright install chromium
 ```
 
-Configure the Browser Mode test files and provider. Keep the `include` pattern narrow so these tests are clearly separate from the rest of a test suite:
+Configure the test files and provider. Keep the `include` pattern narrow so these tests stay separate from the rest of the suite:
 
 ```ts
 // vitest.config.ts
@@ -39,13 +39,13 @@ export default defineConfig({
 });
 ```
 
-Run the browser tests with your normal Vitest command. For CI, add `headless: true` inside `browser`; Vitest otherwise opens its browser UI during local development.
+Run the browser tests with your normal Vitest command. For CI, add `headless: true` inside `browser`. Without it, Vitest opens its browser UI, which is what you want locally.
 
-If the repository also has deterministic DOM tests, add Browser Mode as one named project. The [testing overview](/testing) shows how to choose the right layer; its project layout is intentionally kept out of this page.
+If the repository also has deterministic DOM tests, add Browser Mode as one named project. The [testing overview](/testing) covers that layout.
 
 ## Test a real scroll transition
 
-Use [Vitest's React Browser API](https://vitest.dev/api/browser/react) to render React components and make retriable assertions in the browser. This example proves both sides of the interaction: the target begins outside the viewport, then becomes visible only after native scrolling changes the real layout.
+Use [Vitest's React Browser API](https://vitest.dev/api/browser/react) to render components and make retriable assertions in the browser. This example proves both sides of the interaction. The target starts outside the viewport, and only becomes visible after real scrolling changes the layout.
 
 ```tsx
 import { render } from "vitest-browser-react";
@@ -82,10 +82,10 @@ test("updates when the target scrolls into the viewport", async () => {
 });
 ```
 
-`expect.element` retries in the browser, so the final assertion waits for the observer callback instead of relying on arbitrary timers.
+`expect.element` retries in the browser, so the final assertion waits for the observer callback instead of guessing at a timer value.
 
 ## Keep the native observer native
 
-Do not import `react-intersection-observer/test-utils` in Browser Mode setup. Its mock replaces the browser API, so the test would no longer prove scrolling, layout, or native observer delivery.
+Do not import `react-intersection-observer/test-utils` in Browser Mode setup. Its mock replaces the browser API, and the test stops proving anything about scrolling, layout, or native observer delivery.
 
-For a callback or threshold branch that does not need physical geometry, use [mock intersections](/testing/mocking-intersections). That guide covers `happy-dom`, `jsdom`, Jest, Vitest, and the mock's automatic or manual setup.
+For a callback or threshold branch that does not need real geometry, use [mock intersections](/testing/mocking-intersections). That guide covers `happy-dom`, `jsdom`, Jest, Vitest, and both automatic and manual setup.

--- a/apps/docs/docs/testing/index.mdx
+++ b/apps/docs/docs/testing/index.mdx
@@ -1,28 +1,28 @@
 ---
 title: Testing
-description: Choose the test surface that matches the behavior you need to prove.
+description: Choose the test layer that matches the behavior you need to prove.
 sidebar:
   order: 1
 ---
 
-Intersection Observer tests fall into two categories. Pick the boundary first, then use the focused guide for that kind of test.
+Intersection Observer tests fall into two groups. Pick the layer first, then follow the guide for that kind of test.
 
-## Choose a test boundary
+## Choose a test layer
 
 | You need to prove… | Start here |
 | --- | --- |
-| Actual scrolling, geometry, or native observer behavior | [Browser Mode](/testing/browser-mode) |
+| Real scrolling, geometry, or native observer behavior | [Browser Mode](/testing/browser-mode) |
 | A deterministic callback, state transition, or threshold branch in Vitest or Jest | [Mock intersections](/testing/mocking-intersections) |
 
-Browser Mode and the package mock are complementary. Browser Mode verifies browser integration; the mock creates deterministic observer signals. Keep a native browser test free of a global mock setup.
+The two work together. Browser Mode verifies browser integration, and the mock produces deterministic observer signals. Keep the global mock setup out of native browser tests.
 
 ## Organize a mixed suite
 
-Keep each test boundary in its own named project so the DOM mock never leaks into native browser tests:
+Give each layer its own named project so the DOM mock never leaks into native browser tests:
 
 | Behavior | Project | Typical files | Setup |
 | --- | --- | --- | --- |
-| Real scrolling, layout, and native observer delivery | `browser` | `*.browser.test.tsx` | Vitest Browser Mode; no global test utilities. |
+| Real scrolling, layout, and native observer delivery | `browser` | `*.browser.test.tsx` | Vitest Browser Mode, with no global test utilities. |
 | Deterministic callbacks and thresholds | `dom` | `*.dom.test.tsx` | `happy-dom` or `jsdom` plus `test-utils`. |
 
-The Browser Mode and mock setup guides show the project-specific configuration.
+Both guides show the configuration for their own project.

--- a/apps/docs/docs/testing/mocking-intersections.mdx
+++ b/apps/docs/docs/testing/mocking-intersections.mdx
@@ -103,7 +103,7 @@ test("ignores the initial false notification", () => {
 });
 ```
 
-Pass a boolean to enter or leave. A number selects which configured thresholds the observer has crossed. It is not a layout ratio: the mock reports the highest crossed threshold as `entry.intersectionRatio`. Assert threshold behavior, not raw geometry or an arbitrary percentage.
+Pass a boolean to enter or leave. A number selects which of the configured thresholds the observer has crossed, and the mock reports the highest crossed one as `entry.intersectionRatio`. Assert against the thresholds you configured.
 
 These examples work the same in Vitest and Jest. Switch to [Browser Mode](/testing/browser-mode) when a test has to prove real browser behavior.
 

--- a/apps/docs/docs/testing/mocking-intersections.mdx
+++ b/apps/docs/docs/testing/mocking-intersections.mdx
@@ -3,13 +3,13 @@ title: Mock intersections
 description: Drive deterministic observer callbacks and thresholds in Vitest, Jest, or another DOM-capable test runner.
 ---
 
-Use `react-intersection-observer/test-utils` when the assertion is about a callback, state transition, or threshold branch—not physical layout. The utilities replace `window.IntersectionObserver`, remember the elements each mock observer is watching, and let a helper deliver controlled entries to the registered callback. The mocks exercise observer callbacks as well as state transitions.
+Use `react-intersection-observer/test-utils` when the assertion is about a callback, state transition, or threshold branch rather than real layout. The utilities replace `window.IntersectionObserver`, remember which elements each mock observer watches, and let a helper deliver controlled entries to the registered callback.
 
 ## Set up the mock
 
-Importing `test-utils` in a DOM test environment can set up the mock automatically. When the module finds global `beforeEach`, `afterEach`, and either `vi` or `jest`, it registers hooks: the `beforeEach` hook installs the observer mock with that runner's `fn`, and the `afterEach` hook clears mock calls and observed elements. Observed elements are reset between tests, not only mock calls. Put the import in a test setup file so every relevant test gets the same lifecycle.
+Importing `test-utils` in a DOM test environment can set the mock up for you. When the module finds global `beforeEach`, `afterEach`, and either `vi` or `jest`, it registers its own hooks. The `beforeEach` hook installs the observer mock with that runner's `fn`. The `afterEach` hook clears both the mock calls and the observed elements, so nothing carries between tests. Put the import in a setup file so every relevant test gets the same lifecycle.
 
-Install one DOM emulator for deterministic tests first. `happy-dom` is often faster; `jsdom` may be a better fit for an existing suite. Neither proves layout, scrolling, or native observer delivery.
+Install a DOM emulator first. `happy-dom` is usually faster, and `jsdom` may fit an existing suite better. Neither one proves layout, scrolling, or native observer delivery.
 
 ```bash
 pnpm add -D happy-dom
@@ -44,11 +44,11 @@ module.exports = {
 
 </CodeGroup>
 
-The mock is runner-agnostic: Jest is not coupled to `jsdom`, and Vitest can use either `jsdom` or `happy-dom`. In a mixed Vitest suite, isolate this setup in a `dom` project; do not inherit it into [Browser Mode](/testing/browser-mode) tests.
+The mock does not care which runner you use. Jest is not tied to `jsdom`, and Vitest works with either `jsdom` or `happy-dom`. In a mixed Vitest suite, keep this setup in a `dom` project so it never reaches the [Browser Mode](/testing/browser-mode) tests.
 
 ### Manual setup without globals
 
-If your runner does not expose global test APIs—or you intentionally use imported APIs—register the lifecycle yourself. `setupIntersectionMocking` accepts the runner's mock factory; `resetIntersectionMocking` clears it after every test.
+If your runner does not expose global test APIs, or you prefer importing them, register the lifecycle yourself. `setupIntersectionMocking` takes the runner's mock factory, and `resetIntersectionMocking` clears it after every test.
 
 <CodeGroup>
 
@@ -78,7 +78,7 @@ afterEach(resetIntersectionMocking);
 
 ## Drive a transition
 
-With either setup above in place, import a helper in the test and trigger the observer state you need:
+With either setup in place, import a helper and trigger the observer state you need:
 
 ```tsx
 import { render } from "@testing-library/react";
@@ -103,9 +103,9 @@ test("ignores the initial false notification", () => {
 });
 ```
 
-Pass a boolean to enter or leave. A numeric value selects the configured thresholds the observer has crossed; it is not a physical layout ratio. The mock reports the highest crossed observer threshold as `entry.intersectionRatio`, so assert threshold behavior rather than raw geometry or an arbitrary percentage.
+Pass a boolean to enter or leave. A number selects which configured thresholds the observer has crossed. It is not a layout ratio: the mock reports the highest crossed threshold as `entry.intersectionRatio`. Assert threshold behavior, not raw geometry or an arbitrary percentage.
 
-Use the same deterministic transition examples in Vitest and Jest. Reach for [Browser Mode](/testing/browser-mode) when a test must prove real browser behavior.
+These examples work the same in Vitest and Jest. Switch to [Browser Mode](/testing/browser-mode) when a test has to prove real browser behavior.
 
 ## Utilities
 
@@ -119,5 +119,5 @@ Use the same deterministic transition examples in Vitest and Jest. Reach for [Br
 | `destroyIntersectionMocking()` | Restore the native observer after mocking it. |
 
 :::note
-The mock can exercise a `trackVisibility` fallback branch, but cannot prove actual v2 occlusion. Treat that API as experimental and verify it in a supported browser if your product depends on it.
+The mock can drive a `trackVisibility` fallback branch, but it cannot prove real v2 occlusion. Treat that API as experimental, and verify it in a supported browser if your product depends on it.
 :::

--- a/apps/docs/islands/ObserverDemo.tsx
+++ b/apps/docs/islands/ObserverDemo.tsx
@@ -80,12 +80,12 @@ function LiveObserverDemo() {
           >
             Step 2 · Scroll this panel to reveal the observed card ↓
           </div>
-          <FeedTeaser label="Design systems that travel" tone="warm" />
-          <FeedTeaser label="A quiet note on shipping" tone="cool" />
-          <FeedTeaser label="Small details, deliberately timed" tone="warm" />
-          <FeedTeaser label="A scroll worth observing" tone="cool" />
-          <FeedTeaser label="A detail worth loading" tone="warm" />
-          <FeedTeaser label="One more thing to notice" tone="cool" />
+          <FeedTeaser label="Feed item 1" tone="warm" />
+          <FeedTeaser label="Feed item 2" tone="cool" />
+          <FeedTeaser label="Feed item 3" tone="warm" />
+          <FeedTeaser label="Feed item 4" tone="cool" />
+          <FeedTeaser label="Feed item 5" tone="warm" />
+          <FeedTeaser label="Feed item 6" tone="cool" />
 
           <article
             ref={ref}
@@ -192,9 +192,9 @@ function LiveObserverDemo() {
             </div>
           </article>
 
-          <FeedTeaser label="Where interaction begins" tone="cool" />
-          <FeedTeaser label="A follow-up for the reader" tone="warm" />
-          <FeedTeaser label="The next item is already waiting" tone="cool" />
+          <FeedTeaser label="Feed item 7" tone="cool" />
+          <FeedTeaser label="Feed item 8" tone="warm" />
+          <FeedTeaser label="Feed item 9" tone="cool" />
         </section>
 
         <aside

--- a/apps/docs/pages/_home/Landing.tsx
+++ b/apps/docs/pages/_home/Landing.tsx
@@ -544,8 +544,7 @@ function ApiStepCard({
 /* Lazy strip: defer the work until the target is near                */
 /* ================================================================== */
 
-/* Stand-in artwork. Inline SVG keeps the demo self-contained, so a tile that
-   has not been reached yet costs nothing and the page pulls no extra files. */
+/* Stand-in artwork, inline so an unreached tile costs nothing. */
 function art(from: string, to: string, seed: number) {
   const svg =
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120">` +
@@ -570,10 +569,7 @@ const PHOTOS = [
 
 function LazyStrip() {
   const ref = useSectionSignal("lazy", "Lazy loading");
-  const [loaded, setLoaded] = useState<string[]>([]);
-  const markLoaded = useCallback((id: string) => {
-    setLoaded((current) => (current.includes(id) ? current : [...current, id]));
-  }, []);
+  const [loaded, setLoaded] = useState(0);
 
   return (
     <section className="rio-section rio-lazy" ref={ref}>
@@ -593,7 +589,7 @@ function LazyStrip() {
             <LazyTile
               index={i}
               key={photo.id}
-              onLoad={markLoaded}
+              onLoad={() => setLoaded((n) => n + 1)}
               photo={photo}
             />
           ))}
@@ -602,7 +598,7 @@ function LazyStrip() {
         <aside className="rio-lazy__panel">
           <div className="rio-counter">
             <span className="rio-counter__num">
-              {loaded.length}
+              {loaded}
               <span className="rio-counter__of">/{PHOTOS.length}</span>
             </span>
             <span className="rio-counter__label">images requested</span>
@@ -651,16 +647,15 @@ function LazyTile({
 }: {
   photo: { id: string; src: string };
   index: number;
-  onLoad: (id: string) => void;
+  onLoad: () => void;
 }) {
   const { ref, inView } = useInView({
     rootMargin: "200px 0px",
     triggerOnce: true,
+    onChange: (visible) => {
+      if (visible) onLoad();
+    },
   });
-
-  useEffect(() => {
-    if (inView) onLoad(photo.id);
-  }, [inView, onLoad, photo.id]);
 
   return (
     <figure className="rio-shot" data-loaded={inView} ref={ref}>

--- a/apps/docs/pages/_home/Landing.tsx
+++ b/apps/docs/pages/_home/Landing.tsx
@@ -49,6 +49,7 @@ export default function Landing() {
         <Hero />
         <RevealBand />
         <ApiScrollspy />
+        <LazyStrip />
         <ImpressionStrip />
         <Playground />
         <ClosingCta />
@@ -70,9 +71,9 @@ function Hero() {
         <div className="rio-hero__copy">
           <h1 className="rio-h1">Know when an element meets the viewport.</h1>
           <p className="rio-lead">
-            A tiny, fully-typed React adapter for the Intersection Observer API.
-            Reveal on scroll, lazy-load, track impressions, and build infinite
-            lists with one hook and about a kilobyte.
+            Reveal on scroll, lazy-load images, track impressions, build
+            infinite lists. A tiny, fully-typed React adapter for the
+            Intersection Observer API, in about a kilobyte.
           </p>
 
           <InstallCommand />
@@ -536,6 +537,156 @@ function ApiStepCard({
       {/* Mobile: each step carries its own snippet (sticky panel is hidden). */}
       <Code className="rio-step__code" lines={step.code} />
     </li>
+  );
+}
+
+/* ================================================================== */
+/* Lazy strip: defer the work until the target is near                */
+/* ================================================================== */
+
+/* Stand-in artwork. Inline SVG keeps the demo self-contained, so a tile that
+   has not been reached yet costs nothing and the page pulls no extra files. */
+function art(from: string, to: string, seed: number) {
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120">` +
+    `<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1">` +
+    `<stop offset="0" stop-color="${from}"/><stop offset="1" stop-color="${to}"/>` +
+    `</linearGradient></defs>` +
+    `<rect width="160" height="120" fill="url(#g)"/>` +
+    `<circle cx="${40 + seed * 17}" cy="${38 + seed * 9}" r="26" fill="#fff" opacity=".18"/>` +
+    `<circle cx="${118 - seed * 11}" cy="${86 - seed * 7}" r="34" fill="#000" opacity=".12"/>` +
+    `</svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+const PHOTOS = [
+  { id: "hero.jpg", src: art("#7c3aed", "#2563eb", 0) },
+  { id: "cover.jpg", src: art("#0ea5e9", "#14b8a6", 1) },
+  { id: "avatar.jpg", src: art("#f59e0b", "#ef4444", 2) },
+  { id: "chart.jpg", src: art("#10b981", "#0ea5e9", 3) },
+  { id: "banner.jpg", src: art("#8b5cf6", "#ec4899", 4) },
+  { id: "thumb.jpg", src: art("#6366f1", "#22d3ee", 5) },
+];
+
+function LazyStrip() {
+  const ref = useSectionSignal("lazy", "Lazy loading");
+  const [loaded, setLoaded] = useState<string[]>([]);
+  const markLoaded = useCallback((id: string) => {
+    setLoaded((current) => (current.includes(id) ? current : [...current, id]));
+  }, []);
+
+  return (
+    <section className="rio-section rio-lazy" ref={ref}>
+      <Reveal className="rio-head">
+        <h2 className="rio-h2">Load it just before it is needed.</h2>
+        <p className="rio-subhead">
+          Every tile below reserves its space, then mounts its{" "}
+          <code className="rio-inline">&lt;img&gt;</code> once the observer says
+          it is within 200px of the viewport. Nothing above the fold waits on
+          artwork that is still three screens away.
+        </p>
+      </Reveal>
+
+      <div className="rio-lazy__layout">
+        <div className="rio-lazy__grid">
+          {PHOTOS.map((photo, i) => (
+            <LazyTile
+              index={i}
+              key={photo.id}
+              onLoad={markLoaded}
+              photo={photo}
+            />
+          ))}
+        </div>
+
+        <aside className="rio-lazy__panel">
+          <div className="rio-counter">
+            <span className="rio-counter__num">
+              {loaded.length}
+              <span className="rio-counter__of">/{PHOTOS.length}</span>
+            </span>
+            <span className="rio-counter__label">images requested</span>
+          </div>
+          <Code
+            className="rio-lazy__code"
+            label="defer until near"
+            lines={[
+              [
+                c.k("const"),
+                c.t(" { ref, "),
+                c.t("inView"),
+                c.t(" } = "),
+                c.f("useInView"),
+                c.t("({"),
+              ],
+              [c.t("  rootMargin: "), c.s('"200px 0px"'), c.t(",")],
+              [c.t("  triggerOnce: "), c.k("true"), c.t(",")],
+              [c.t("});")],
+              [],
+              [c.c("// .frame holds the space either way")],
+              [c.t("<div ref={ref} className="), c.s('"frame"'), c.t(">")],
+              [c.t("  {inView ? <img src={src} /> : "), c.k("null"), c.t("}")],
+              [c.t("</div>")],
+            ]}
+          />
+        </aside>
+      </div>
+
+      <Reveal className="rio-band__note">
+        <Icon name="feather" size={16} />
+        <span>
+          Plain images want <code className="rio-inline">loading="lazy"</code>{" "}
+          instead. Reach for the observer when you need the preload margin, a
+          placeholder, or a transition.
+        </span>
+      </Reveal>
+    </section>
+  );
+}
+
+function LazyTile({
+  photo,
+  index,
+  onLoad,
+}: {
+  photo: { id: string; src: string };
+  index: number;
+  onLoad: (id: string) => void;
+}) {
+  const { ref, inView } = useInView({
+    rootMargin: "200px 0px",
+    triggerOnce: true,
+  });
+
+  useEffect(() => {
+    if (inView) onLoad(photo.id);
+  }, [inView, onLoad, photo.id]);
+
+  return (
+    <figure className="rio-shot" data-loaded={inView} ref={ref}>
+      <div className="rio-shot__frame">
+        {inView ? (
+          <img alt="" className="rio-shot__img" src={photo.src} />
+        ) : (
+          <span className="rio-shot__skeleton" />
+        )}
+      </div>
+      <figcaption className="rio-shot__meta">
+        <span className="rio-shot__name">{photo.id}</span>
+        <span className="rio-shot__state">
+          {inView ? (
+            <>
+              <Icon name="check" size={13} /> loaded
+            </>
+          ) : (
+            "deferred"
+          )}
+        </span>
+      </figcaption>
+      <span className="rio-shot__index" aria-hidden="true">
+        {String(index + 1).padStart(2, "0")}
+      </span>
+    </figure>
   );
 }
 

--- a/apps/docs/pages/_home/Landing.tsx
+++ b/apps/docs/pages/_home/Landing.tsx
@@ -121,7 +121,7 @@ function InstallCommand() {
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1600);
     } catch {
-      /* clipboard unavailable — no-op */
+      /* clipboard unavailable, no-op */
     }
   }, [command]);
 
@@ -164,7 +164,7 @@ function InstallCommand() {
   );
 }
 
-/** Live telemetry instrument — reflects the page's own observation. */
+/** Live telemetry instrument. Reflects the page's own observation. */
 function Instrument() {
   const { snapshot } = useObserver();
   const reduced = usePrefersReducedMotion();
@@ -224,7 +224,7 @@ function Readout({
 }
 
 /* ================================================================== */
-/* Reveal band — scroll-triggered animation                            */
+/* Reveal band: scroll-triggered animation                           */
 /* ================================================================== */
 
 type Feature = {
@@ -309,7 +309,7 @@ function RevealBand() {
 }
 
 /* ================================================================== */
-/* API scrollspy — three APIs, one observer                            */
+/* API scrollspy: three APIs, one observer                           */
 /* ================================================================== */
 
 type ApiStep = {
@@ -348,7 +348,7 @@ const API_STEPS: ApiStep[] = [
     name: "useOnInView",
     signature: "(inView, entry) => void",
     blurb:
-      "Run an effect without a hook-owned re-render. Ideal for analytics, prefetching, or logging.",
+      "Run an effect without a hook-owned re-render. Use it for analytics, prefetching, and logging.",
     code: [
       [c.k("const"), c.t(" ref = "), c.f("useOnInView"), c.t("(")],
       [c.t("  (inView, entry) => {")],
@@ -540,7 +540,7 @@ function ApiStepCard({
 }
 
 /* ================================================================== */
-/* Impression strip — fire once, when seen                             */
+/* Impression strip: fire once, when seen                            */
 /* ================================================================== */
 
 const TILES = [
@@ -637,7 +637,7 @@ function ImpressionTile({ id, index }: { id: string; index: number }) {
 }
 
 /* ================================================================== */
-/* Playground — the existing interactive demo                          */
+/* Playground: the existing interactive demo                         */
 /* ================================================================== */
 
 function Playground() {
@@ -668,7 +668,7 @@ function ClosingCta() {
     <section className="rio-section rio-closing" ref={ref}>
       <Reveal className="rio-closing__inner">
         <h2 className="rio-h2 rio-closing__title">
-          Add a kilobyte. Ship the viewport.
+          Add a kilobyte. Know what is on screen.
         </h2>
         <p className="rio-subhead rio-closing__lead">
           Install, attach a ref, and read{" "}
@@ -702,7 +702,7 @@ function ClosingCta() {
 }
 
 /* ================================================================== */
-/* Floating HUD — the page watching itself                             */
+/* Floating HUD: the page watching itself                            */
 /* ================================================================== */
 
 function Hud() {

--- a/apps/docs/pages/_home/home.css
+++ b/apps/docs/pages/_home/home.css
@@ -1014,8 +1014,8 @@
   border-color: color-mix(in srgb, var(--rio-emerald) 45%, transparent);
 }
 
-/* The frame reserves the tile's space before the image exists, so loading one
-   never shifts the rows below it. This is the part that is easy to skip. */
+/* Reserves the tile's space before the image exists, so loading one never
+   shifts the rows below it. */
 .rio-shot__frame {
   aspect-ratio: 4 / 3;
   border-radius: 8px;
@@ -1099,9 +1099,8 @@
   color: var(--rio-emerald);
 }
 
-/* The badge sits over the frame, so it has to read against both the empty
-   placeholder (theme-coloured) and the loaded artwork (always dark enough
-   for white). Two states, not one colour that only works on one of them. */
+/* The badge sits over the frame, so it needs one color for the theme-tinted
+   placeholder and another for the artwork it covers once loaded. */
 .rio-shot__index {
   position: absolute;
   top: 1rem;

--- a/apps/docs/pages/_home/home.css
+++ b/apps/docs/pages/_home/home.css
@@ -975,6 +975,154 @@
   color: var(--rio-muted);
 }
 
+.rio-counter__of {
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--rio-muted);
+}
+
+/* ------------------------------------------------------------- */
+/* Lazy strip                                                     */
+/* ------------------------------------------------------------- */
+
+.rio-lazy__layout {
+  display: grid;
+  grid-template-columns: 1.35fr 0.65fr;
+  gap: clamp(1.25rem, 3vw, 2.5rem);
+  align-items: start;
+}
+
+.rio-lazy__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+  gap: 0.75rem;
+}
+
+.rio-shot {
+  position: relative;
+  margin: 0;
+  padding: 0.55rem;
+  border-radius: 12px;
+  border: 1px solid var(--rio-line);
+  background: var(--rio-surface);
+  transition:
+    border-color 0.4s ease,
+    background 0.4s ease;
+}
+
+.rio-shot[data-loaded="true"] {
+  border-color: color-mix(in srgb, var(--rio-emerald) 45%, transparent);
+}
+
+/* The frame reserves the tile's space before the image exists, so loading one
+   never shifts the rows below it. This is the part that is easy to skip. */
+.rio-shot__frame {
+  aspect-ratio: 4 / 3;
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--rio-surface-2);
+}
+
+.rio-shot__img {
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
+  object-fit: cover;
+  animation: rio-shot-in 0.45s ease both;
+}
+
+@keyframes rio-shot-in {
+  from {
+    opacity: 0;
+    filter: blur(8px);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+  }
+}
+
+/* Placeholder shimmer. Held still for anyone who asked for reduced motion. */
+.rio-shot__skeleton {
+  display: block;
+  block-size: 100%;
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    color-mix(in srgb, var(--rio-fg) 8%, transparent) 50%,
+    transparent 70%
+  );
+  background-size: 220% 100%;
+  animation: rio-shot-shimmer 1.6s linear infinite;
+}
+
+@keyframes rio-shot-shimmer {
+  from {
+    background-position: 120% 0;
+  }
+  to {
+    background-position: -120% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rio-shot__img {
+    animation: none;
+  }
+  .rio-shot__skeleton {
+    animation: none;
+  }
+}
+
+.rio-shot__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  font-family: var(--rio-mono);
+  font-size: 0.72rem;
+}
+
+.rio-shot__name {
+  font-weight: 600;
+}
+
+.rio-shot__state {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--rio-muted);
+}
+
+.rio-shot[data-loaded="true"] .rio-shot__state {
+  color: var(--rio-emerald);
+}
+
+/* The badge sits over the frame, so it has to read against both the empty
+   placeholder (theme-coloured) and the loaded artwork (always dark enough
+   for white). Two states, not one colour that only works on one of them. */
+.rio-shot__index {
+  position: absolute;
+  top: 1rem;
+  right: 1.1rem;
+  font-family: var(--rio-mono);
+  font-size: 0.72rem;
+  color: color-mix(in srgb, var(--rio-fg) 45%, transparent);
+}
+
+.rio-shot[data-loaded="true"] .rio-shot__index {
+  color: color-mix(in srgb, #fff 75%, transparent);
+  text-shadow: 0 1px 3px rgb(0 0 0 / 0.45);
+}
+
+.rio-lazy__panel {
+  position: sticky;
+  top: 6rem;
+  display: grid;
+  gap: 1rem;
+}
+
 /* ------------------------------------------------------------- */
 /* Playground                                                     */
 /* ------------------------------------------------------------- */
@@ -1192,10 +1340,12 @@
   .rio-step__code {
     display: block;
   }
-  .rio-impr__layout {
+  .rio-impr__layout,
+  .rio-lazy__layout {
     grid-template-columns: 1fr;
   }
-  .rio-impr__panel {
+  .rio-impr__panel,
+  .rio-lazy__panel {
     position: static;
     grid-template-columns: 1fr 1fr;
   }
@@ -1205,11 +1355,15 @@
   .rio-hud {
     display: none;
   }
-  .rio-impr__panel {
+  .rio-impr__panel,
+  .rio-lazy__panel {
     grid-template-columns: 1fr;
   }
   .rio-impr__grid {
     grid-template-columns: repeat(auto-fill, minmax(7.5rem, 1fr));
+  }
+  .rio-lazy__grid {
+    grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
   }
 
   /* Closing CTA: the primary action spans the row, GitHub and npm share the

--- a/apps/docs/pages/_home/home.css
+++ b/apps/docs/pages/_home/home.css
@@ -1,5 +1,5 @@
 /* ============================================================== */
-/* Landing page — React Intersection Observer                     */
+/* Landing page: React Intersection Observer                     */
 /* Everything follows Blume's theme: chrome, panels, code, and     */
 /* instrument all adapt to light and dark. Tokens derive from the  */
 /* --color-* theme vars; the few that can't (code syntax, focal    */
@@ -160,8 +160,9 @@
 }
 
 /* Scroll reveal. Elements are hidden (opacity 0) only when the inline head
-   script in index.astro has set `data-rio-js` — i.e. JS is present and motion
-   is allowed — so they start hidden before first paint and never fade out.
+   script in index.astro has set `data-rio-js`, meaning JS is present and
+   motion is allowed, so they start hidden before first paint and never fade
+   out.
    With no JS or reduced motion the flag is absent and content stays visible.
    The island adds `is-visible` as each element enters the viewport. */
 :root[data-rio-js] .rio-reveal {
@@ -847,7 +848,7 @@
   border-radius: 999px;
 }
 
-/* Syntax token colors — theme-aware (values set on .rio-home + dark override). */
+/* Syntax token colors, theme-aware (values set on .rio-home + dark override). */
 .rio-tok--t {
   color: var(--rio-code-fg);
 }

--- a/apps/docs/pages/_home/primitives.tsx
+++ b/apps/docs/pages/_home/primitives.tsx
@@ -284,6 +284,14 @@ const ICON_PATHS: Record<string, ReactNode> = {
       <path d="M7 18v-8h3v6M10 12h1M13 18v-8h4v8M15 10v6" />
     </>
   ),
+  image: (
+    <>
+      <rect x="3" y="4" width="18" height="16" rx="2" />
+      <circle cx="8.5" cy="9.5" r="1.5" />
+      <path d="m4 17 4.5-4.5a2 2 0 0 1 2.8 0L15 16" />
+      <path d="m14 15 1.6-1.6a2 2 0 0 1 2.8 0L20 15" />
+    </>
+  ),
 };
 
 export function Icon({

--- a/apps/docs/pages/_home/primitives.tsx
+++ b/apps/docs/pages/_home/primitives.tsx
@@ -28,7 +28,7 @@ export function usePrefersReducedMotion(): boolean {
 }
 
 /* ------------------------------------------------------------------ */
-/* Observer telemetry context — the page watching itself               */
+/* Observer telemetry context: the page watching itself              */
 /* ------------------------------------------------------------------ */
 
 type Snapshot = {
@@ -141,7 +141,7 @@ export function useSectionSignal(id: string, label: string) {
 }
 
 /* ------------------------------------------------------------------ */
-/* Reveal — the scroll-triggered entrance, driven by the library       */
+/* Reveal: the scroll-triggered entrance, driven by the library      */
 /* ------------------------------------------------------------------ */
 
 /**
@@ -194,7 +194,7 @@ export function Reveal({
 }
 
 /* ------------------------------------------------------------------ */
-/* Line icons — drawn, single stroke weight                            */
+/* Line icons: drawn, single stroke weight                           */
 /* ------------------------------------------------------------------ */
 
 const ICON_PATHS: Record<string, ReactNode> = {
@@ -318,7 +318,7 @@ export function Icon({
 }
 
 /* ------------------------------------------------------------------ */
-/* Code rendering — token kinds map to theme-aware colors in home.css   */
+/* Code rendering: token kinds map to theme-aware colors in home.css */
 /* (`.rio-tok--*`), so syntax stays readable in light and dark.         */
 /* ------------------------------------------------------------------ */
 

--- a/apps/docs/pages/index.astro
+++ b/apps/docs/pages/index.astro
@@ -21,8 +21,7 @@ const { config } = data;
   ogEnabled={config.og?.enabled}
   ogImage="/og-home.png"
   page={{
-    title:
-      "React Intersection Observer: tiny, typed viewport detection for React",
+    title: "React Intersection Observer: tiny, typed viewport detection",
     description: config.description,
   }}
 >

--- a/apps/storybook/stories/Intro.mdx
+++ b/apps/storybook/stories/Intro.mdx
@@ -2,6 +2,6 @@
 
 A React implementation of the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
 
-Use the stories in this library to explore the `InView` component, `useInView`, and `useOnInView` in isolation.
+The stories here run the `InView` component, `useInView`, and `useOnInView` in isolation, so you can change the options and watch what happens.
 
 For installation, API reference, guides, and recipes, visit the [documentation site](https://react-intersection-observer.thebuilder.dk/).


### PR DESCRIPTION
Pass over every prose file in the repo to remove AI-writing tells and say what the library does rather than how it feels.

## What changed

**README.md** got the most work:

- Feature list: dropped the emoji and the puffery. "🪝 **Hooks or Component API** - With `useInView` and `useOnInView` it's easier than ever to monitor elements" is now "**Hooks or component API** - `useInView` for React state, `useOnInView` for callbacks, `<InView>` for render props and wrapper elements."
- Options table: the `root` row was 45 words of MDN boilerplate. Now one sentence. Same treatment for `skip`, `initialInView`, `fallbackInView`, `children`, and the test-utils method table.
- Cut "In order to", "utilize", "makes it easy", "allows you to", "This is still a very new addition", "Browser support is excellent", "just a simple but powerful tool".
- Headings to sentence case, one em dash removed, the `🧪` markers replaced with the word "Experimental".

**Docs site:**

- `overview.mdx`: "Built for production React" was four bullets of marketing ("Native and efficient", "Testable at the right layer"). Rewritten as "What you get" with actual mechanisms and numbers. Em dashes in the next-steps list gone.
- `ssr.mdx`: had real redundancy. "`initialInView` controls the pre-observer render; it does not create an observer" appeared three separate times, plus an orphan paragraph restating `fallbackInView` vs `defaultFallbackInView` without backticks. One statement each now, 20 lines shorter.
- `configuration.mdx`: unpacked the colon-and-semicolon pileup in "Choose where to observe", dropped a duplicated "root must be an ancestor" sentence.
- `core-apis.mdx`: removed "React surface" (used twice).
- `intersection-observer-v2.mdx`: dropped a duplicated closing line about the mock and occlusion.
- Testing guides: three em dashes removed, dense sentences split.

**CONTRIBUTING.md / SECURITY.md:** "I'm thrilled that you're interested in contributing" is gone, headings to sentence case, "Please ensure that your changes are formatted" became "Format your changes".

## Fixes found along the way

- Broken indentation in the README render-props code sample.
- Typos: `explictly`, `intersecing`, "in test files **were** you actively import", "Ref's from useRef **needs** to have".
- British `specialised` in an otherwise US-spelled doc set (`behavior`, `behaviour` inconsistency).

## Reviewer notes

- **One anchor changed.** Renaming `## Stop, pause, or choose a callback API` to `## Stop or pause observation` changed its slug, so the referring link in `core-apis.mdx` is updated to match. I grepped for the other renamed headings (`Hydration considerations`, `Choose a test boundary`, `Start simple`) and nothing links to them.
- **Content, not just style.** The README option descriptions were rewritten rather than trimmed, so they're worth reading for accuracy. Same for the `overview.mdx` "What you get" bullets, which now make specific claims (shared observer instances, ~1.15kB gzipped) that should match reality.
- `pnpm --filter docs build` passes, 112 pages.
